### PR TITLE
feat: add specifications and guidelines for semantic linking and name…

### DIFF
--- a/agentspecs/README.md
+++ b/agentspecs/README.md
@@ -1,0 +1,91 @@
+# AgentSpecs
+
+This directory holds **specifications and proposals** used by agents (and humans) to implement features in the codebase. It is the single source of truth for *what* to build and *how* it should behave.
+
+## High-level structure
+
+- **`changes/`** — Work in progress. Each item here is a change or feature currently being designed or implemented.
+- **`specs/`** — Consolidated specifications. Completed or released specs live here, organized by domain and feature.
+- **`guidelines/`** — Architectural guidelines (how to structure layers, use cases, and related patterns). Read these when implementing so code matches the intended architecture.
+
+When reading the codebase, check **`changes/`** for active work, **`specs/`** for stable, agreed behavior, and **`guidelines/`** for architectural rules.
+
+## Organization
+
+### Under `changes/`
+
+Each change has its **own folder** (e.g. `changes/universal_search_special_characters/`). Inside that folder there must be:
+
+| File | Purpose |
+|------|--------|
+| **`proposal.md`** | Context, goal, scope, and proposed technical direction. Use it as the development guide for code logic. |
+| **`specs.md`** | Concrete, testable requirements (often in Gherkin). Use it to write integration/acceptance tests and to verify behavior. |
+
+Naming: use a short, snake_case folder name that describes the change (e.g. `universal_search_special_characters`).
+
+### Under `specs/`
+
+Consolidated specs are organized **by domain, then by feature**:
+
+```
+specs/
+  <domain>/           e.g. security, search, catalog
+    <feature>/        e.g. auth, universal_search
+      spec.md         single consolidated spec file for that feature
+```
+
+Only **spec** content is kept here (no `proposal.md`). The file is named **`spec.md`** (singular). Copy or merge from the `specs.md` in `changes/` when promoting a change.
+
+### Under `guidelines/`
+
+The **`guidelines/`** package holds **architectural guidelines** for this codebase (markdown documents describing layers, use-case structure, and similar conventions). Consult them alongside `proposal.md` when implementing so new code follows the agreed architecture.
+
+**Entry point — what each guide contains:**
+
+- **`USE_CASE_IMPLEMENTATION.md`** — How the use-case flow is wired from REST through controllers, use-case services, factories, domain commands, presenters, and outbound ports (and how adapters sit behind those ports).
+- **`GENERIC-CRUD-GUIDELINES.md`** — How to implement CRUD with the template-method `GenericCrud*` service hierarchy (JPA entities, optional DTO mapping, optional specification-based filtering).
+
+---
+
+## How to work (agent guidelines)
+
+### 1. For each change under `changes/`
+
+- Ensure the change folder contains both **`proposal.md`** and **`specs.md`**.
+- If either is missing, ask for it before implementing.
+
+### 2. Implementing code — follow this order
+
+Follow these steps **in this exact order**:
+
+1. **Read** `proposal.md` and `specs.md` in the change folder.
+2. **Implement integration/acceptance tests** following `specs.md` (e.g. Gherkin scenarios → test cases).  
+   Add a **comment at the top of each test method** that references the corresponding requirement or scenario in the spec (e.g. section title, requirement ID, or Gherkin block), so tests can be traced back to the specification.
+3. **Verify** that those tests **fail** (expected behavior not yet implemented).
+4. **Implement** the code logic so the tests pass. Use `proposal.md` as the development guide.
+5. **Verify** that the tests **pass**.
+
+**Loop steps 4–5** until all tests pass.
+
+### 3. After implementation
+
+- **Review** the `specs.md` under `changes/` for **coherence** with the code you modified: update the spec if behavior or edge cases changed, or add missing scenarios.
+
+### 4. When the change is finished (consolidation)
+
+- **Move** the change into `specs/` by:
+  - **Copying only the spec file(s)** (i.e. the content of `specs.md` from the change).
+  - Placing it under **`specs/<domain>/<feature>/spec.md`**, following the structure: **domains first**, then **features**.
+- Optionally remove or archive the folder under `changes/` once the spec is consolidated.
+
+---
+
+## Summary
+
+| Location | Meaning | Contents |
+|----------|--------|----------|
+| **`changes/<name>/`** | Current WIP | `proposal.md` + `specs.md` |
+| **`specs/<domain>/<feature>/`** | Consolidated | `spec.md` only (from specs) |
+| **`guidelines/`** | Architecture | Markdown docs (e.g. use-case patterns) |
+
+Workflow: **read proposal + specs → write ITs from specs → see tests fail → implement from proposal → see tests pass → review spec coherence → copy spec into `specs/` by domain/feature.**

--- a/agentspecs/guidelines/GENERIC-CRUD-GUIDELINES.md
+++ b/agentspecs/guidelines/GENERIC-CRUD-GUIDELINES.md
@@ -1,0 +1,119 @@
+# Generic CRUD services (template method pattern)
+
+CRUD can be implemented through a small hierarchy of abstract classes that follow the **template method** pattern: the base class defines the **algorithm** (order of steps, transactions, error handling), and subclasses supply **hooks** and **type-specific behavior** by implementing abstract methods and optionally overriding protected hook methods.
+
+---
+
+## Class hierarchy
+
+| Layer | Interface | Implementation | Purpose |
+| ----- | --------- | -------------- | ------- |
+| Entity CRUD | `GenericCrudService<T, ID>` | `GenericCrudServiceImpl<T, ID>` | Persistence for JPA entities `T` with id `ID`. |
+| + API mapping | `GenericMappedCrudService<R, T, ID>` | `GenericMappedCrudServiceImpl<R, T, ID>` | Adds REST/DTO type `R`: map `R ↔ T` and expose `*Resource` methods. |
+| + filtering | `GenericMappedAndFilteredCrudService<F, R, T, ID>` | `GenericMappedAndFilteredCrudServiceImpl<F, R, T, ID>` | Adds filter object `F` and specification-based list queries. |
+
+**Type parameters**
+
+- **`T`** — JPA entity.
+- **`ID`** — Primary key type (`Serializable`, e.g. `Long`, `String`).
+- **`R`** — API resource / DTO returned to callers.
+- **`F`** — Search or filter options used to build a JPA `Specification<T>`.
+
+Pick the **shallowest** layer that fits: if the API does not need a separate `R`, you might only extend `GenericCrudServiceImpl`. When list endpoints support query filters and you expose DTOs, use **`GenericMappedAndFilteredCrudServiceImpl`**.
+
+---
+
+## What you must implement
+
+### `GenericCrudServiceImpl<T, ID>`
+
+1. **`getRepository()`** — Return a repository that supports CRUD, paging/sorting, and JPA specifications (e.g. a type extending `CrudRepository`, `PagingAndSortingRepository`, and `JpaSpecificationExecutor`).
+
+2. **`validate(T)`** — Business and field validation before create/overwrite. Throw your domain or API-layer exceptions on failure.
+
+3. **`reconcile(T)`** — Resolve references, defaults, or denormalized state after validation and before save (e.g. load related entities by foreign key).
+
+Optional **hooks** (empty defaults; override when needed):
+
+- **Read:** `afterFindOne(T, ID)`
+- **Create:** `beforeCreation(T)`, `afterCreation(T, T)`, `afterCreationCommit(T)`
+- **Update:** `beforeOverwrite(T)`, `afterOverWrite(T, T)`, `afterOverwriteCommit(T)`
+- **Delete:** `beforeDelete(ID)`, `afterDelete(ID)`, `afterDeleteCommit(T)` (used with `deleteReturning`)
+
+**Utilities:** `exists(ID)` is protected; `checkExistenceOrThrow(ID)` and `findOne(ID)` typically throw a not-found exception when the row is missing.
+
+### `GenericMappedCrudServiceImpl<R, T, ID>`
+
+Adds mapping between API and persistence:
+
+1. **`toRes(T entity)`** — Entity → API resource.
+2. **`toEntity(R resource)`** — API resource → entity (for incoming bodies).
+
+Delegation to a dedicated mapper class is common. Mapped operations are:
+
+- `findAllResources` / `findOneResource` / `createResource` / `overwriteResource` / `deleteReturningResource`
+
+### `GenericMappedAndFilteredCrudServiceImpl<F, R, T, ID>`
+
+1. **`getSpecFromFilters(F filters)`** — Build a `Specification<T>`, often by composing smaller specs (e.g. AND-combining a list of predicates).
+
+2. **`getRepository()`** — May be declared again in this class so the implementation satisfies the abstract method from the filtered layer (same bean as in `GenericCrudServiceImpl`).
+
+**Note:** `findAllFiltered` runs `getRepository().findAll(spec, pageable)`. Override `findAll` / `findAllResources` only if you need different list behavior (for example, disabling generic pagination for a given aggregate).
+
+---
+
+## Fixed algorithm (template method)
+
+The base class fixes the **order of operations**; subclasses should not change the sequence unless they intentionally override a public method (usually avoided).
+
+**Create:** `validate` → `reconcile` → `beforeCreation` → `save` → `afterCreation` → (after transaction) → `afterCreationCommit`
+
+**Overwrite:** `validate` → existence check → `reconcile` → `beforeOverwrite` → `save` → `afterOverWrite` → `afterOverwriteCommit`
+
+**Delete:** existence check → `beforeDelete` → `deleteById` → `afterDelete`
+
+**`deleteReturning`:** `findOne` → map with provided `Function` → `delete` → `afterDeleteCommit`
+
+Create/overwrite/delete bodies typically use Spring’s **`TransactionTemplate`** so the transactional boundary is explicit inside the generic implementation. Read paths may use a small **`TransactionHandler`** (or equivalent) with `@Transactional` for mapped/filtered reads so lazy loading and mapping run inside a transactional boundary when needed.
+
+---
+
+## Transactions: two mechanisms
+
+- **`TransactionTemplate`** (in `GenericCrudServiceImpl`): used for writes in the generic CRUD flow.
+- **`TransactionHandler`** (or similar) in mapped layers: transactional wrapper for read operations that map entities to resources.
+
+When one service calls another (e.g. loading a related entity in `reconcile`), use the existing service API and stay aware of transaction boundaries if you need atomicity across multiple aggregates.
+
+---
+
+## Controllers and public API
+
+- Prefer **`…Resource` methods** for HTTP adapters so the layer works with `R`, not entities.
+- If path parameters must **override** fields in the body (e.g. id in URL vs body), override the `*Resource` method, set the field from the path, then call `super`.
+
+---
+
+## Example shape (conceptual)
+
+A typical filtered, mapped service:
+
+- Extends `GenericMappedAndFilteredCrudServiceImpl<MySearchOptions, MyResource, MyEntity, MyIdType>`.
+- Implements `validate`, `reconcile`, `getSpecFromFilters`, `getRepository`, `toRes`, `toEntity`.
+- Uses `beforeCreation` / `beforeOverwrite` for rules that depend on persisted state (e.g. uniqueness excluding the current row).
+- Builds `Specification` instances from filter fields, composed with AND/OR as needed.
+
+---
+
+## Design tips
+
+1. **Keep `validate` focused** on invariants, format, and required fields; use **`reconcile`** for loading associations and fixing navigable graphs before `save`.
+
+2. **Use hooks** for database-dependent rules (uniqueness excluding self, side effects) so they run in the same transaction as `save` / `delete`.
+
+3. **Repository** must support paging and specifications if you use the filtered base class; static nested `Spec` helpers on the repository are a common style.
+
+4. **Throw** exceptions that your global handler maps to HTTP status codes consistently.
+
+5. If an aggregate **must not** support generic `findAll(Pageable)`, override those methods and throw an explicit “not supported” (or equivalent) with a clear message.

--- a/agentspecs/guidelines/USE_CASE_IMPLEMENTATION.md
+++ b/agentspecs/guidelines/USE_CASE_IMPLEMENTATION.md
@@ -1,0 +1,187 @@
+# Guidelines: Implementing a Use Case
+
+This document describes how use cases are structured: REST surface, application orchestration, factories, domain commands, presenters, and outbound ports.
+
+## Architecture at a glance
+
+The flow is:
+
+**HTTP** → **Controller** (`*UseCaseController`) → **Use cases service** (`*UseCasesService`) → **Factory** (`*Factory`) → **Use case** (implements `UseCase`) → **Outbound ports** (interfaces) → **Adapters** (`*OutboundPortImpl`) → **Core / infrastructure** (CRUD services, clients, etc.).
+
+- The **use case** stays free of Spring and HTTP: it receives a **command** (domain input) and talks to the outside world only through **ports**.
+- The **presenter** is the use case’s output boundary: it receives domain results (e.g. `presentX(...)`).
+- The **factory** is the composition root for a single use case: it wires concrete port implementations and returns a `UseCase` instance.
+- The **use cases service** adapts REST DTOs to commands, runs the use case, and maps domain results back to API resources.
+
+### Hard boundaries (use case package)
+
+- **REST resources (`*CommandRes`, `*ResultRes`, and any `*Res` under `rest.v<*>.resources`) MUST NOT** be referenced inside the use case package (`...services.usecases.*`). They belong to the HTTP adapter; only the **use cases service** (and controller) may use them.
+- **Commands** passed into the use case MUST carry **domain data only**: JPA **entities**, value types, or **small immutable records** you declare for denormalized input—never API DTOs.
+- **Presenters** MUST accept **domain results** (entities, domain records, or primitives)—not `*Res` types.
+- **Outbound port implementations** (`*OutboundPortImpl`) MUST be **plain Java classes** (no `@Component`, `@Service`, or other Spring stereotypes). The **factory** is the only `@Component` in that slice: it constructs port impls with `new` and passes **Spring-injected collaborators** (core services, mappers, clients, `TransactionalOutboundPort`) into their constructors. Port interfaces stay free of framework types.
+
+```mermaid
+flowchart LR
+  subgraph rest [REST]
+    C[UseCaseController]
+    DTO[CommandRes / ResultRes]
+  end
+  subgraph app [Application]
+    UCS[*UseCasesService]
+    F[*Factory]
+    UC[Use case class]
+  end
+  subgraph boundaries [Boundaries]
+    Cmd[Command record]
+    Pres[Presenter interface]
+    P[Outbound ports]
+  end
+  C --> UCS
+  DTO --> UCS
+  UCS --> Cmd
+  UCS --> F
+  F --> UC
+  UC --> Cmd
+  UC --> Pres
+  UC --> P
+```
+
+
+
+---
+
+## 1. Shared building blocks (`utils.usecases`)
+
+
+| Artifact                    | Role                                                                                                                                                                                                                  |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UseCase`                   | Single method: `void execute()`. Every use case class implements this interface.                                                                                                                                      |
+| `TransactionalOutboundPort` | Wraps work in a transaction (`doInTransaction`, `doInTransactionWithResults`). Injected into factories; implemented by `DefaultTransactionalOutboundPortImpl` (Spring `TransactionTemplate`, serializable isolation). |
+
+
+Use the transactional port inside the use case when the operation must be atomic (typical for persistence + side effects that belong in the same transaction).
+
+---
+
+## 2. REST API: controller and resources
+
+### Controller
+
+- **Package:** `...controllers`
+- **Class name:** `*UseCaseController` (e.g. `DataProductUseCaseController`).
+- **Annotations:** `@RestController`, `@RequestMapping`, `produces = MediaType.APPLICATION_JSON_VALUE`.
+- **Responsibility:** Map HTTP to the corresponding `*UseCasesService` method only. No business rules.
+- **OpenAPI:** `@Tag`, `@Operation`, `@ApiResponses`, `@Parameter`; use `@Schema(implementation = ...)` on responses where applicable. Use `@Hidden` for endpoints that should not appear in public API docs.
+
+### Resources (DTOs)
+
+- **Package:** `rest.v2.resources.<aggregate>.usecases.<verb>` (e.g. `...dataproduct.usecases.init`).
+- **Naming:**
+  - Request body: `*CommandRes` (e.g. `DataProductInitCommandRes`).
+  - Response body: `*ResultRes` when returning payload (e.g. `DataProductInitResultRes`).
+- **Content:** JavaBeans with getters/setters (and empty constructor for Jackson), fields documented with `@Schema` where useful.
+- **Mapping:** Use existing mappers under `rest.v2.resources` (e.g. `DataProductMapper`, `DataProductRepoMapper`) to convert between `*Res` and **domain entities** inside the use cases service—not inside the controller.
+
+---
+
+## 3. Use cases service (`*UseCasesService`)
+
+- **Package:** `...<aggregate>.services` (e.g. `dataproduct.services`).
+- **Annotation:** `@Service`.
+- **Responsibility:**
+  1. Convert `*CommandRes` → domain **command** (record) using mappers (`toEntity`, etc.). This is the **only** layer that bridges `*Res` ↔ entities for the use case.
+  2. Build a **presenter** implementation:
+    - Often a **private static inner class** `*ResultHolder` that implements the presenter interface and stores the last `present*` argument for later `getResult()`.
+    - For void outcomes, a **lambda** implementing the presenter is acceptable when there is nothing to return (e.g. delete).
+  3. Call `factory.build...(command, presenter).execute()`.
+  4. Map domain result to `*ResultRes` when needed.
+
+Keep this class as the single place that knows both REST mappers and use-case boundaries for that aggregate’s use cases.
+
+---
+
+## 4. Use case package layout
+
+For one behavioral slice (e.g. “initialize data product”), colocate under `...services.usecases.<name>`:
+
+
+| File                     | Purpose                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `<Name>.java`            | Use case class: `class <Name> implements UseCase`, **package-private**.              |
+| `<Name>Command.java`     | Input: **Java `record`** (or equivalent) holding **entities** and/or **declared domain records**—never `*Res` types. |
+| `<Name>Presenter.java`   | Output boundary: methods use **domain types** only (e.g. `presentRegistered(Blueprint entity)`), not REST DTOs. |
+| `<Name>Factory.java`     | **`@Component`** (sole Spring bean here); method `UseCase build...(Command, Presenter)`. Instantiates port impls with `new`. |
+| `*OutboundPort.java`     | Port interfaces (persistence, validation, notification, …). Domain-level method signatures. |
+| `*OutboundPortImpl.java` | **Plain classes** (not Spring beans): implement ports; receive collaborators via constructor only. |
+
+
+Optional: split ports by concern (`...PersistenceOutboundPort`, `...NotificationOutboundPort`, `...ValidationOutboundPort`, etc.).
+
+---
+
+## 5. Use case class
+
+- Implements `UseCase` and implements `execute()`.
+- **Constructor** receives: command, presenter, outbound ports, and `TransactionalOutboundPort` when transactions are required.
+- **Visibility:** package-private (`class Foo implements UseCase`) so only the factory in the same package constructs it.
+- **Logic:** Validate command; orchestrate ports; call presenter methods when the business outcome is ready. Throw domain/API exceptions (`BadRequestException`, etc.) for invalid state. Must contain ONLY business logic.
+- **No** `@Autowired` on the use case class itself.
+- **No** spring annotations on the use case class itself.
+
+---
+
+## 6. Command and presenter
+
+- **Command:** Immutable **record** with **domain types only** (entities, UUIDs, enums, or small records you define in the use case package for structured input). **Never** use `*Res` / REST resources in the command.
+- **Presenter:** Interface named `<Action>Presenter` with one or more `present...` methods using **domain types** for arguments. The use case calls these to push results outward; the use cases service maps domain results to `*ResultRes` for HTTP.
+
+---
+
+## 7. Factories (`*Factory`)
+
+- `**@Component`** in the same package as the use case (typically the **only** `@Component` in that package).
+- **Inject** Spring beans needed to **construct** port implementations: core services (`*Service`, `*CrudService`), `TransactionalOutboundPort`, clients, **MapStruct mappers** between entities and `*Res` when ports need them, etc.
+- **Method signature:** `public UseCase build<Name>(<Name>Command command, <Name>Presenter presenter)`.
+- **Inside:** `new <Name>OutboundPortImpl(...)` for each port—**never** register port impls as Spring beans. Pass `new <Name>(command, presenter, ...ports, transactionalOutboundPort)`.
+
+The factory is the only place that chooses concrete port implementations for that use case.
+
+---
+
+## 8. Outbound ports and adapters
+
+- **Interface:** `<UseCase><Concern>OutboundPort` (e.g. `DataProductInitializerPersistenceOutboundPort`). Methods express what the use case needs in **domain terms** (`save(Blueprint)`, `validate(Blueprint)`, `emit...`)—not SQL, REST, or `*Res` types.
+- **Implementation:** `<UseCase><Concern>OutboundPortImpl` is a **plain Java class** (no `@Component` / `@Service`). It receives **constructor-injected** collaborators supplied by the factory (core `*Service`, mappers, clients). It may call:
+  - **Core layer** services (e.g. `DataProductsService`, `DescriptorVariableCrudService`), or
+  - **Clients** (e.g. `NotificationClient`), with entity ↔ `*Res` mapping **inside the impl** when the core API still uses resources.
+- **Visibility:** Port interfaces and their impls are often **package-private** so the boundary stays inside the use case package.
+- **Transactional port:** Shared across use cases; do not reimplement transaction handling inside each use case—delegate to `TransactionalOutboundPort`.
+- **No Spring on port impls:** If a concern needs to be testable in isolation, use plain `new` in unit tests or test the factory with mocked collaborators—not `@MockBean` on the impl type as a bean.
+
+---
+
+## 9. Core services vs use case layer
+
+- `**...services.core.*`** (and similar): CRUD, queries, reusable domain operations. Use cases **do not** call these directly from the use case class; they go through outbound ports whose impls delegate to core services.
+- `**utils.usecases`:** Cross-cutting use-case infrastructure (`UseCase`, `TransactionalOutboundPort`).
+
+---
+
+## 10. Testing
+
+- Add or extend **integration tests** for use case controllers (e.g. `*UseCaseControllerIT` under `src/test/java/...rest.v2.controllers`) to verify the full stack for the new endpoint.
+- Unit-test complex port adapters or use case logic where it pays off (existing project uses tests such as `*OutboundPortTest` in some areas).
+
+---
+
+## 11. Checklist for a new use case
+
+1. Define **command** record (domain only) and **presenter** interface (domain arguments only) in `...services.usecases.<name>`.
+2. Define **outbound port** interfaces and **plain `*OutboundPortImpl` classes** (no Spring annotations). Implement validation/persistence/etc. with collaborators passed from the factory.
+3. Add **`@Component` factory** only: construct port impls with `new`, inject `TransactionalOutboundPort` and core services/mappers.
+4. Add `***UseCasesService`** methods (or extend an existing one): map `*CommandRes` → entity/command, run factory + `execute()`, map domain result from presenter to `*ResultRes`.
+5. Add `**CommandRes` / `ResultRes**` under `rest.v2.resources...usecases...` with OpenAPI `@Schema` as needed.
+6. Add `**@RestController**` endpoint calling the use cases service; document with OpenAPI.
+7. Add **integration test** for the new route.
+
+Following these steps keeps new behavior consistent with the existing hexagonal-style layout: **ports/adapters** for infrastructure, **use case** for orchestration, **REST** as a thin adapter on top of the use cases service.

--- a/agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md
+++ b/agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md
@@ -1,0 +1,70 @@
+# Spec: Prefixed concept resolution in `s-context`
+
+Canonical spec for this feature. Trace tests via comments on `SemanticLinkManagerTest` methods.
+
+## Feature: Leading bracket concept with namespace prefix
+
+### Scenario: Prefixed root concept resolves in the prefix namespace
+
+**Given** a default namespace N_default identified by `s-base`  
+**And** a second namespace N_other with prefix `other`  
+**And** data category `ConceptB` exists in N_other but not in N_default  
+**When** `enrichWithSemanticContext` runs with a field mapping:
+
+`"field2": "[other:ConceptB].other:attribute2FromConceptB"`
+
+**Then** the adapter MUST look up data category name `ConceptB` using N_other’s UUID  
+**And** the adapter MUST NOT look up the literal name `other:ConceptB` in N_default  
+
+### Scenario: Unprefixed root concept unchanged
+
+**Given** default namespace N_default  
+**And** data category `ConceptA` exists in N_default  
+**When** a field uses `"[ConceptA].someAttribute"` (no prefix inside brackets)  
+**Then** the adapter MUST resolve `ConceptA` in N_default (existing behavior)
+
+### Scenario: Default `s-type` still uses default namespace
+
+**Given** `s-type` is `[ConceptA]` and `s-base` is N_default  
+**When** enrichment runs  
+**Then** `ConceptA` MUST be resolved in N_default  
+
+## Feature: Namespace prefix resolution
+
+### Scenario: Unknown prefix surfaces a clear outcome
+
+**Given** no namespace exists with prefix `unknown`  
+**When** a path references `[unknown:SomeConcept]`  
+**Then** the adapter MUST NOT treat `unknown:SomeConcept` as a single concept name in the default namespace  
+**And** resolution MUST fail or log a defined warning according to product rules (document actual choice in implementation)
+
+### Scenario: Ambiguous prefix (if multiple namespaces match)
+
+**Given** two namespaces share the same prefix (misconfiguration)  
+**When** a path uses that prefix in `[prefix:Concept]`  
+**Then** the adapter MUST NOT silently attach an arbitrary namespace (prefer explicit error or warn + skip)
+
+## Feature: Blindata path passthrough
+
+### Scenario: Semantic link resolution still receives the original path
+
+**Given** a field path as authored in the descriptor (including `prefix:` inside brackets and on attributes where applicable)  
+**When** `getSemanticLinkElements` is invoked  
+**Then** the `pathString` argument MUST match the composed path expected by Blindata for that descriptor (same as today unless Blindata requires a transformation documented in the proposal)
+
+## Non-regression
+
+### Scenario: Stock / luxury style relative paths
+
+**Given** the stock example with `s-type` `[Stock]` and relative segments like `refersTo[lux:ProductSku].lux:productSkuIdentifier`  
+**When** enrichment runs  
+**Then** behavior MUST remain aligned with existing `SemanticLinkManagerTest` expectations (paths and default namespace identifier passed to the client)
+
+---
+
+## Implementation notes (coherence with code)
+
+- **Unknown / ambiguous prefix:** `BdSemanticLinkingClient.getLogicalNamespaceByPrefix` returns a namespace only when Blindata returns exactly one match (`BdClientImpl` requests up to two rows and treats zero or more than one as empty). `SemanticLinkManagerImpl` logs **`[#120]`** *No unique logical namespace found for prefix: …* and skips attaching that concept to the physical entity (no lookup of the bare concept name in the default namespace).
+- **Concept not found:** **`[#89]`** when the name is not found in the resolved namespace UUID; **`[#88]`** when the default `s-type` root concept is missing after namespace resolution.
+- **Default namespace UUID:** Pre-resolution uses `getUuid()` on the namespace returned for `s-base`. Test fixtures under `testSemanticLinking_mockedBlindataResponses_*.json` include a namespace **uuid** where full enrichment is asserted.
+- **Unprefixed leading segment:** Covered by the film-rental integration-style test (`[Movie]`, `[Company]` distributor path, etc.) in `SemanticLinkManagerTest.testEnrichWithSemanticContext`.

--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -623,6 +623,20 @@ In this example:
 - The `ProductSku` concept is in the luxury namespace (prefixed with `lux:`)
 - The relationship `refersTo` connects concepts across different namespaces
 
+#### Leading bracket with namespace prefix (root segment)
+
+When a field path (or `s-type`) starts with an absolute segment of the form **`[prefix:ConceptName]`**, the adapter resolves **`ConceptName`** as a concept in the logical namespace whose Blindata **prefix** matches **`prefix`**, using `s-base` only as the default namespace for Blindata’s `resolvefield` call (the path string passed to Blindata stays exactly as written in the descriptor). Unprefixed roots **`[ConceptName]`** still resolve `ConceptName` in the namespace identified by `s-base`. Example:
+
+```json
+{
+  "s-base": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+  "s-type": "[Movie]",
+  "cross_ref": "[other:ConceptB].other:attribute2FromConceptB"
+}
+```
+
+Here `ConceptB` is loaded from the namespace whose prefix is `other`, not from the default film-rental namespace.
+
 ### Complete Example: Customer Payment System
 
 Here's a comprehensive example showing how semantic linking can be used in a customer payment system:

--- a/docs/validator-error-codes.md
+++ b/docs/validator-error-codes.md
@@ -150,9 +150,10 @@ When the Blindata policy validator evaluates a data product, it logs warning mes
 | `[#85]` | No default namespace identifier provided. |
 | `[#86]` | Namespace not found for identifier. |
 | `[#87]` | No default data category name provided. |
-| `[#88]` | Data category not found in namespace. |
-| `[#89]` | Data category not found. |
+| `[#88]` | Data category not found for the default root concept (message includes category name and namespace label). |
+| `[#89]` | Data category not found for a referenced concept after namespace resolution. |
 | `[#90]` | Unable to resolve semantic elements for semantic link path. |
+| `[#120]` | No unique logical namespace found for prefix (namespace lookup returned none or more than one match). |
 
 ### AsyncAPI and message schema
 

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdClientImpl.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdClientImpl.java
@@ -378,6 +378,33 @@ public class BdClientImpl implements BdDataProductClient, BdStewardshipClient, B
     }
 
     @Override
+    public Optional<BDLogicalNamespaceRes> getLogicalNamespaceByPrefix(String prefix) {
+        if (!StringUtils.hasText(prefix)) {
+            return Optional.empty();
+        }
+        try {
+            BDNamespaceSearchOptions filters = new BDNamespaceSearchOptions();
+            filters.setPrefix(prefix);
+            Page<BDLogicalNamespaceRes> page = restUtils.getPage(
+                    credentials.getBlindataUrl() + "/api/v1/logical/namespaces",
+                    null,
+                    PageRequest.ofSize(2),
+                    filters,
+                    BDLogicalNamespaceRes.class
+            );
+            List<BDLogicalNamespaceRes> matches = page.getContent();
+            if (matches.size() != 1) {
+                return Optional.empty();
+            }
+            return Optional.of(matches.get(0));
+        } catch (ClientException e) {
+            throw new BlindataClientException(e.getCode(), e.getResponseBody());
+        } catch (ClientResourceMappingException e) {
+            throw new BlindataClientResourceMappingException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public BDQualityUploadResultsRes uploadQuality(BDQualityUploadRes qualityUpload) {
         try {
             RestUtils rest = credentials.getEnableAsync() ? asyncRestUtils : restUtils;

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdSemanticLinkingClient.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdSemanticLinkingClient.java
@@ -13,4 +13,6 @@ public interface BdSemanticLinkingClient {
     Optional<BDDataCategoryRes> getDataCategoryByNameAndNamespaceUuid(String dataCategoryName, String namespaceUuid);
 
     Optional<BDLogicalNamespaceRes> getLogicalNamespaceByIdentifier(String identifier);
+
+    Optional<BDLogicalNamespaceRes> getLogicalNamespaceByPrefix(String prefix);
 }

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/resources/blindata/logical/BDNamespaceSearchOptions.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/resources/blindata/logical/BDNamespaceSearchOptions.java
@@ -6,11 +6,21 @@ public class BDNamespaceSearchOptions {
 
     private List<String> identifiers;
 
+    private String prefix;
+
     public List<String> getIdentifiers() {
         return identifiers;
     }
 
     public void setIdentifiers(List<String> identifiers) {
         this.identifiers = identifiers;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
     }
 }

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/BracketConceptRef.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/BracketConceptRef.java
@@ -1,0 +1,38 @@
+package org.opendatamesh.platform.up.metaservice.blindata.schema_analyzers.semanticlinking;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Concept reference parsed from the inner text of a leading bracket segment
+ * (e.g. {@code Stock} or {@code lux:ProductSku} from {@code [Stock]} / {@code [lux:ProductSku]}).
+ */
+final class BracketConceptRef {
+
+    private static final Pattern PREFIXED_INNER = Pattern.compile("^([A-Za-z0-9_]+):(.+)$");
+
+    private final Optional<String> namespacePrefix;
+    private final String conceptName;
+
+    private BracketConceptRef(String namespacePrefix, String conceptName) {
+        this.namespacePrefix = Optional.ofNullable(namespacePrefix);
+        this.conceptName = conceptName;
+    }
+
+    static BracketConceptRef parse(String innerBracketText) {
+        Matcher m = PREFIXED_INNER.matcher(innerBracketText);
+        if (m.matches()) {
+            return new BracketConceptRef(m.group(1), m.group(2));
+        }
+        return new BracketConceptRef(null, innerBracketText);
+    }
+
+    Optional<String> getNamespacePrefix() {
+        return namespacePrefix;
+    }
+
+    String getConceptName() {
+        return conceptName;
+    }
+}

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/SemanticLinkManagerImpl.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/SemanticLinkManagerImpl.java
@@ -31,11 +31,11 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             Optional<BDLogicalNamespaceRes> resolvedDefaultNamespace = resolveDefaultNamespace(parsedSemanticContext.getDefaultNamespaceIdentifier());
             if (resolvedDefaultNamespace.isEmpty()) return;
 
-            Optional<BDDataCategoryRes> resolvedDefaultDataCategory = resolveDefaultDataCategory(parsedSemanticContext.getDefaultDataCategoryName(), resolvedDefaultNamespace.get());
+            Optional<BDDataCategoryRes> resolvedDefaultDataCategory = resolveDefaultDataCategory(parsedSemanticContext.getDefaultDataCategoryInner(), resolvedDefaultNamespace.get());
             if (resolvedDefaultDataCategory.isEmpty()) return;
 
             Set<BDDataCategoryRes> resolvedDataCategories =
-                    resolveDataCategories(parsedSemanticContext.getDataCategories(), resolvedDefaultNamespace.get());
+                    resolveDataCategories(parsedSemanticContext.getReferencedConcepts(), resolvedDefaultNamespace.get());
             Set<BDPhysicalFieldRes> enrichedPhysicalFields = enrichPhysicalFieldsWithSemanticLinks(physicalEntity.getPhysicalFields(), parsedSemanticContext.getSemanticLinks());
             physicalEntity.setDataCategories(resolvedDataCategories);
             physicalEntity.setPhysicalFields(enrichedPhysicalFields);
@@ -44,13 +44,16 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
 
     private SemanticContext parseSemanticContext(Map<String, Object> semanticContext) {
         String defaultNamespaceIdentifier = Optional.ofNullable((String) semanticContext.get("s-base")).orElse("");
-        String defaultDataCategoryName = Optional.ofNullable((String) semanticContext.get("s-type")).orElse("").replaceAll("[\\[\\]]", "");
+        String defaultDataCategoryInner = Optional.ofNullable((String) semanticContext.get("s-type")).orElse("").replaceAll("[\\[\\]]", "");
+        BracketConceptRef defaultRootRef = BracketConceptRef.parse(defaultDataCategoryInner);
+        Set<BracketConceptRef> initialRefs = new HashSet<>();
+        initialRefs.add(defaultRootRef);
 
         return semanticContext.entrySet().stream()
                 .filter(entry -> !"s-base".equals(entry.getKey()) && !"s-type".equals(entry.getKey()))
-                .map(entry -> parseFieldContext(entry.getKey(), entry.getValue(), "", defaultNamespaceIdentifier, defaultDataCategoryName))
+                .map(entry -> parseFieldContext(entry.getKey(), entry.getValue(), "", defaultNamespaceIdentifier, defaultDataCategoryInner))
                 .reduce(
-                        new SemanticContext(defaultNamespaceIdentifier, defaultDataCategoryName, new HashMap<>(), Set.of(defaultDataCategoryName)),
+                        new SemanticContext(defaultNamespaceIdentifier, defaultDataCategoryInner, new HashMap<>(), initialRefs),
                         SemanticContext::merge
                 );
     }
@@ -60,12 +63,12 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             Object fieldContext,
             String parentPath,
             String defaultNamespaceIdentifier,
-            String defaultDataCategoryName) {
+            String defaultDataCategoryInner) {
 
         if (fieldContext instanceof String) {
-            return handleSimpleSemanticPath(fieldName, (String) fieldContext, parentPath, defaultNamespaceIdentifier, defaultDataCategoryName);
+            return handleSimpleSemanticPath(fieldName, (String) fieldContext, parentPath, defaultNamespaceIdentifier, defaultDataCategoryInner);
         } else if (fieldContext instanceof Map) {
-            return handleNestedSemanticPath(fieldName, (Map<String, Object>) fieldContext, parentPath, defaultNamespaceIdentifier, defaultDataCategoryName);
+            return handleNestedSemanticPath(fieldName, (Map<String, Object>) fieldContext, parentPath, defaultNamespaceIdentifier, defaultDataCategoryInner);
         }
         return new SemanticContext();
     }
@@ -75,16 +78,16 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             String semanticPath,
             String parentPath,
             String defaultNamespaceIdentifier,
-            String defaultDataCategoryName
+            String defaultDataCategoryInner
     ) {
         String fullPath = isAbsoluteSemanticPath(semanticPath) ? semanticPath : (parentPath.isEmpty() ? semanticPath : parentPath + "." + semanticPath);
 
-        Set<String> dataCategories = new HashSet<>();
+        Set<BracketConceptRef> referencedConcepts = new HashSet<>();
         if (isAbsoluteSemanticPath(fullPath)) {
-            String startingConcept = fullPath.substring(0, fullPath.indexOf("]") + 1).replaceAll("[\\[\\]]", "");
-            dataCategories.add(startingConcept);
+            String startingInner = fullPath.substring(0, fullPath.indexOf("]") + 1).replaceAll("[\\[\\]]", "");
+            referencedConcepts.add(BracketConceptRef.parse(startingInner));
         } else {
-            fullPath = StringUtils.hasText(defaultDataCategoryName) ? "[" + defaultDataCategoryName + "]" + "." + fullPath : fullPath;
+            fullPath = StringUtils.hasText(defaultDataCategoryInner) ? "[" + defaultDataCategoryInner + "]" + "." + fullPath : fullPath;
         }
 
         BDSemanticLink semanticLink = new BDSemanticLink();
@@ -92,7 +95,7 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
         semanticLink.setSemanticLinkString(fullPath);
         Map<String, BDSemanticLink> semanticLinks = Map.of(fieldName, semanticLink);
 
-        return new SemanticContext(defaultNamespaceIdentifier, defaultDataCategoryName, semanticLinks, dataCategories);
+        return new SemanticContext(defaultNamespaceIdentifier, defaultDataCategoryInner, semanticLinks, referencedConcepts);
     }
 
     // Used for nested field, like in AVRO
@@ -107,7 +110,7 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             Map<String, Object> nestedContext,
             String parentPath,
             String defaultNamespaceIdentifier,
-            String defaultDataCategoryName
+            String defaultDataCategoryInner
     ) {
         SemanticContext semanticContext = new SemanticContext();
 
@@ -116,7 +119,7 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             if (!"s-type".equals(entry.getKey())) {
                 String nestedFieldName = entry.getKey();
                 String effectiveParentPath = parentPath.isEmpty() ? nestedType : parentPath + "." + nestedType;
-                SemanticContext childContext = parseFieldContext(fieldName + "." + nestedFieldName, entry.getValue(), effectiveParentPath, defaultNamespaceIdentifier, defaultDataCategoryName);
+                SemanticContext childContext = parseFieldContext(fieldName + "." + nestedFieldName, entry.getValue(), effectiveParentPath, defaultNamespaceIdentifier, defaultDataCategoryInner);
                 semanticContext = semanticContext.merge(childContext);
             }
         }
@@ -136,25 +139,53 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
         return resolvedNamespace;
     }
 
-    private Optional<BDDataCategoryRes> resolveDefaultDataCategory(String defaultDataCategoryName, BDLogicalNamespaceRes defaultNamespace) {
-        if (!StringUtils.hasText(defaultDataCategoryName)) {
+    private Optional<BDDataCategoryRes> resolveDefaultDataCategory(String defaultDataCategoryInner, BDLogicalNamespaceRes defaultNamespace) {
+        BracketConceptRef ref = BracketConceptRef.parse(defaultDataCategoryInner);
+        if (!StringUtils.hasText(ref.getConceptName())) {
             getUseCaseLogger().warn("[#87] No default data category name provided.");
             return Optional.empty();
         }
 
-        Optional<BDDataCategoryRes> resolvedDataCategory = client.getDataCategoryByNameAndNamespaceUuid(defaultDataCategoryName, defaultNamespace.getUuid());
+        Optional<String> targetNamespaceUuid = resolveNamespaceUuidForConceptRef(ref, defaultNamespace);
+
+        Optional<BDDataCategoryRes> resolvedDataCategory = client.getDataCategoryByNameAndNamespaceUuid(ref.getConceptName(), targetNamespaceUuid.orElse(null));
         if (resolvedDataCategory.isEmpty()) {
-            getUseCaseLogger().warn("[#88] Data category: " + defaultDataCategoryName + " not found in namespace " + defaultNamespace.getIdentifier());
+            String namespaceLabel = ref.getNamespacePrefix().map(p -> "prefix " + p).orElseGet(defaultNamespace::getIdentifier);
+            getUseCaseLogger().warn("[#88] Data category: " + ref.getConceptName() + " not found in namespace " + namespaceLabel);
         }
         return resolvedDataCategory;
     }
 
-    private Set<BDDataCategoryRes> resolveDataCategories(Set<String> dataCategories, BDLogicalNamespaceRes defaultNamespace) {
-        return dataCategories.stream()
-                .map(dataCategoryName -> {
-                    Optional<BDDataCategoryRes> resolved = client.getDataCategoryByNameAndNamespaceUuid(dataCategoryName, defaultNamespace.getUuid());
+    private Optional<String> resolveNamespaceUuidForConceptRef(BracketConceptRef ref, BDLogicalNamespaceRes defaultNamespace) {
+        if (ref.getNamespacePrefix().isEmpty()) {
+            return Optional.ofNullable(defaultNamespace.getUuid());
+        }
+        String prefix = ref.getNamespacePrefix().get();
+        Optional<BDLogicalNamespaceRes> resolved = client.getLogicalNamespaceByPrefix(prefix);
+        if (resolved.isEmpty()) {
+            getUseCaseLogger().warn("[#120] No unique logical namespace found for prefix: " + prefix);
+            return Optional.empty();
+        }
+        if (resolved.get().getUuid() == null) {
+            getUseCaseLogger().warn("[#120] No unique logical namespace found for prefix: " + prefix);
+            return Optional.empty();
+        }
+        return Optional.of(resolved.get().getUuid());
+    }
+
+    private Set<BDDataCategoryRes> resolveDataCategories(Set<BracketConceptRef> referencedConcepts, BDLogicalNamespaceRes defaultNamespace) {
+        return referencedConcepts.stream()
+                .map(ref -> {
+                    if (!StringUtils.hasText(ref.getConceptName())) {
+                        return Optional.<BDDataCategoryRes>empty();
+                    }
+                    Optional<String> namespaceUuid = resolveNamespaceUuidForConceptRef(ref, defaultNamespace);
+                    if (namespaceUuid.isEmpty()) {
+                        return Optional.<BDDataCategoryRes>empty();
+                    }
+                    Optional<BDDataCategoryRes> resolved = client.getDataCategoryByNameAndNamespaceUuid(ref.getConceptName(), namespaceUuid.get());
                     if (resolved.isEmpty()) {
-                        getUseCaseLogger().warn("[#89] Data category: " + dataCategoryName + " not found");
+                        getUseCaseLogger().warn("[#89] Data category: " + ref.getConceptName() + " not found");
                     }
                     return resolved;
                 })
@@ -197,18 +228,18 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
     private class SemanticContext {
 
         String defaultNamespaceIdentifier;
-        String defaultDataCategoryName;
+        String defaultDataCategoryInner;
         Map<String, BDSemanticLink> semanticLinks;
-        Set<String> dataCategories;
+        Set<BracketConceptRef> referencedConcepts;
 
         public SemanticContext() {
         }
 
-        public SemanticContext(String defaultNamespaceIdentifier, String defaultDataCategoryName, Map<String, BDSemanticLink> semanticLinks, Set<String> dataCategories) {
+        public SemanticContext(String defaultNamespaceIdentifier, String defaultDataCategoryInner, Map<String, BDSemanticLink> semanticLinks, Set<BracketConceptRef> referencedConcepts) {
             this.defaultNamespaceIdentifier = defaultNamespaceIdentifier;
-            this.defaultDataCategoryName = defaultDataCategoryName;
+            this.defaultDataCategoryInner = defaultDataCategoryInner;
             this.semanticLinks = semanticLinks;
-            this.dataCategories = dataCategories;
+            this.referencedConcepts = referencedConcepts;
         }
 
         public String getDefaultNamespaceIdentifier() {
@@ -219,12 +250,12 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             this.defaultNamespaceIdentifier = defaultNamespaceIdentifier;
         }
 
-        public String getDefaultDataCategoryName() {
-            return defaultDataCategoryName;
+        public String getDefaultDataCategoryInner() {
+            return defaultDataCategoryInner;
         }
 
-        public void setDefaultDataCategoryName(String defaultDataCategoryName) {
-            this.defaultDataCategoryName = defaultDataCategoryName;
+        public void setDefaultDataCategoryInner(String defaultDataCategoryInner) {
+            this.defaultDataCategoryInner = defaultDataCategoryInner;
         }
 
         public Map<String, BDSemanticLink> getSemanticLinks() {
@@ -235,32 +266,32 @@ class SemanticLinkManagerImpl implements SemanticLinkManager {
             this.semanticLinks = semanticLinks;
         }
 
-        public Set<String> getDataCategories() {
-            return dataCategories;
+        public Set<BracketConceptRef> getReferencedConcepts() {
+            return referencedConcepts;
         }
 
-        public void setDataCategories(Set<String> dataCategories) {
-            this.dataCategories = dataCategories;
+        public void setReferencedConcepts(Set<BracketConceptRef> referencedConcepts) {
+            this.referencedConcepts = referencedConcepts;
         }
 
         public SemanticContext merge(SemanticContext other) {
             String mergedNamespaceIdentifier =
                     other.defaultNamespaceIdentifier != null ? other.defaultNamespaceIdentifier : this.defaultNamespaceIdentifier;
 
-            String mergedDataCategoryName =
-                    other.defaultDataCategoryName != null ? other.defaultDataCategoryName : this.defaultDataCategoryName;
+            String mergedDataCategoryInner =
+                    other.defaultDataCategoryInner != null ? other.defaultDataCategoryInner : this.defaultDataCategoryInner;
 
             Map<String, BDSemanticLink> mergedLinks = new HashMap<>(this.semanticLinks != null ? this.semanticLinks : Map.of());
             if (other.semanticLinks != null) {
                 mergedLinks.putAll(other.semanticLinks);
             }
 
-            Set<String> mergedCategories = new HashSet<>(this.dataCategories != null ? this.dataCategories : Set.of());
-            if (other.dataCategories != null) {
-                mergedCategories.addAll(other.dataCategories);
+            Set<BracketConceptRef> mergedRefs = new HashSet<>(this.referencedConcepts != null ? this.referencedConcepts : Set.of());
+            if (other.referencedConcepts != null) {
+                mergedRefs.addAll(other.referencedConcepts);
             }
 
-            return new SemanticContext(mergedNamespaceIdentifier, mergedDataCategoryName, mergedLinks, mergedCategories);
+            return new SemanticContext(mergedNamespaceIdentifier, mergedDataCategoryInner, mergedLinks, mergedRefs);
         }
     }
 

--- a/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/SemanticLinkManagerTest.java
+++ b/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/SemanticLinkManagerTest.java
@@ -3,9 +3,9 @@ package org.opendatamesh.platform.up.metaservice.blindata.schema_analyzers.seman
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opendatamesh.platform.up.metaservice.blindata.client.blindata.BdSemanticLinkingClient;
@@ -23,8 +23,12 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SemanticLinkManagerTest {
@@ -34,13 +38,24 @@ class SemanticLinkManagerTest {
     @Mock
     private BdSemanticLinkingClient mockSemanticLinkingClient;
 
-    @InjectMocks
     private SemanticLinkManagerImpl semanticLinkManager;
 
+    @BeforeEach
+    void createSemanticLinkManager() {
+        semanticLinkManager = new SemanticLinkManagerImpl(mockSemanticLinkingClient);
+    }
+
+    /**
+     * {@code agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md} — Non-regression: film-rental
+     * fixture (unprefixed roots, nested {@code s-type}, {@code [Company]} path); namespace mock includes UUID for
+     * pre-resolution.
+     */
     @Test
     void testEnrichWithSemanticContext() throws IOException {
-        // set up
+        reset(mockSemanticLinkingClient);
+        semanticLinkManager = new SemanticLinkManagerImpl(mockSemanticLinkingClient);
         setUpMocks();
+
         Map<String, Object> sContext = objectMapper.readValue(
                 Resources.toByteArray(getClass().getResource("testSemanticLinking_semanticContext.json")),
                 Map.class
@@ -58,9 +73,238 @@ class SemanticLinkManagerTest {
         assertThat(physicalEntity).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedPhysicalEntity);
     }
 
+    /**
+     * {@code agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md}
+     * —
+     * Feature: Leading bracket concept with namespace prefix — Scenario: Prefixed
+     * root concept resolves in the prefix namespace.
+     */
+    @Test
+    void prefixedRootConceptResolvesInPrefixNamespace() throws IOException {
+            reset(mockSemanticLinkingClient);
+            BDLogicalNamespaceRes defaultNs = new BDLogicalNamespaceRes();
+            defaultNs.setIdentifier("https://demo.blindata.io/logical/namespaces/name/filmRentalInc#");
+            defaultNs.setUuid("film-rental-namespace-uuid");
+            defaultNs.setPrefix("fri");
+
+            BDLogicalNamespaceRes otherNs = new BDLogicalNamespaceRes();
+            otherNs.setName("OtherOntology");
+            otherNs.setDisplayName("Other ontology");
+            otherNs.setIdentifier("https://demo.blindata.io/logical/namespaces/name/otherOntology#");
+            otherNs.setUuid("other-namespace-uuid");
+            otherNs.setPrefix("other");
+            otherNs.setDescription("Separate logical namespace reached via prefix other");
+
+            defaultNs.setName("FilmRentalInc");
+            defaultNs.setDisplayName("Film Rental Inc");
+            defaultNs.setDescription("Namespace for the business ontology of Film Rental Inc");
+
+            when(mockSemanticLinkingClient.getLogicalNamespaceByIdentifier(defaultNs.getIdentifier()))
+                            .thenReturn(Optional.of(defaultNs));
+            when(mockSemanticLinkingClient.getLogicalNamespaceByPrefix("other")).thenReturn(Optional.of(otherNs));
+
+            BDDataCategoryRes movie = new BDDataCategoryRes();
+            movie.setName("Movie");
+            movie.setDisplayName("Movie");
+            movie.setDescription("Movie data such as title, release year, length, rating, etc.");
+            movie.setNamespace(defaultNs);
+
+            BDDataCategoryRes conceptB = new BDDataCategoryRes();
+            conceptB.setName("ConceptB");
+            conceptB.setDisplayName("Concept B");
+            conceptB.setDescription("Concept used for cross-namespace prefixed path tests.");
+            conceptB.setNamespace(otherNs);
+
+            when(mockSemanticLinkingClient.getDataCategoryByNameAndNamespaceUuid(anyString(), anyString()))
+                            .thenAnswer(invocation -> {
+                                    String name = invocation.getArgument(0);
+                                    String uuid = invocation.getArgument(1);
+                                    if ("Movie".equals(name) && defaultNs.getUuid().equals(uuid)) {
+                                            return Optional.of(movie);
+                                    }
+                                    if ("ConceptB".equals(name) && otherNs.getUuid().equals(uuid)) {
+                                            return Optional.of(conceptB);
+                                    }
+                                    return Optional.empty();
+                            });
+
+            Map<String, BDLogicalFieldSemanticLinkRes> semanticLinkElements = objectMapper.readValue(
+                            Resources.toByteArray(getClass().getResource(
+                                            "testSemanticLinking_prefixedConcept_mockedBlindataResponses_semanticLinkElements.json")),
+                            new TypeReference<Map<String, BDLogicalFieldSemanticLinkRes>>() {
+                            });
+            when(mockSemanticLinkingClient.getSemanticLinkElements(anyString(), anyString()))
+                            .thenAnswer(invocation -> semanticLinkElements.get(invocation.getArgument(0)));
+
+            Map<String, Object> sContext = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_prefixedConcept_semanticContext.json")),
+                            Map.class);
+            BDPhysicalEntityRes physicalEntity = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_prefixedConcept_rawPhysicalEntity.json")),
+                            BDPhysicalEntityRes.class);
+
+            semanticLinkManager.enrichWithSemanticContext(physicalEntity, sContext);
+
+            verify(mockSemanticLinkingClient, never()).getDataCategoryByNameAndNamespaceUuid(eq("other:ConceptB"),
+                            anyString());
+            verify(mockSemanticLinkingClient).getDataCategoryByNameAndNamespaceUuid("ConceptB", otherNs.getUuid());
+            verify(mockSemanticLinkingClient).getSemanticLinkElements(
+                            "[other:ConceptB].other:attribute2FromConceptB",
+                            defaultNs.getIdentifier());
+            assertThat(physicalEntity.getDataCategories())
+                            .extracting(BDDataCategoryRes::getName)
+                            .containsExactlyInAnyOrder("Movie", "ConceptB");
+            assertThat(physicalEntity.getDataCategories())
+                            .filteredOn(dc -> "ConceptB".equals(dc.getName()))
+                            .singleElement()
+                            .extracting(BDDataCategoryRes::getNamespace)
+                            .returns("other", ns -> ns.getPrefix());
+            BDPhysicalFieldRes crossField = physicalEntity.getPhysicalFields().stream()
+                            .filter(f -> "cross_field".equals(f.getName()))
+                            .findFirst()
+                            .orElseThrow();
+            assertThat(crossField.getLogicalFields()).hasSize(1);
+            assertThat(crossField.getLogicalFields().get(0).getSemanticLink().getSemanticLinkString())
+                            .isEqualTo("[other:ConceptB].other:attribute2FromConceptB");
+    }
+
+    /**
+     * {@code agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md}
+     * —
+     * Feature: Namespace prefix resolution — Scenario: Unknown prefix surfaces a
+     * clear outcome (no literal composite name lookup in default namespace).
+     */
+    @Test
+    void unknownPrefixDoesNotLookupLiteralCompositeNameInDefaultNamespace() throws IOException {
+            reset(mockSemanticLinkingClient);
+            BDLogicalNamespaceRes defaultNs = new BDLogicalNamespaceRes();
+            defaultNs.setIdentifier("https://demo.blindata.io/logical/namespaces/name/filmRentalInc#");
+            defaultNs.setUuid("film-rental-namespace-uuid");
+            defaultNs.setPrefix("fri");
+
+            when(mockSemanticLinkingClient.getLogicalNamespaceByIdentifier(defaultNs.getIdentifier()))
+                            .thenReturn(Optional.of(defaultNs));
+            when(mockSemanticLinkingClient.getLogicalNamespaceByPrefix("unknown")).thenReturn(Optional.empty());
+
+            BDDataCategoryRes movie = new BDDataCategoryRes();
+            movie.setName("Movie");
+            movie.setNamespace(defaultNs);
+            when(mockSemanticLinkingClient.getDataCategoryByNameAndNamespaceUuid("Movie", defaultNs.getUuid()))
+                            .thenReturn(Optional.of(movie));
+
+            Map<String, Object> sContext = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_unknownPrefix_semanticContext.json")),
+                            Map.class);
+            BDPhysicalEntityRes physicalEntity = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_unknownPrefix_rawPhysicalEntity.json")),
+                            BDPhysicalEntityRes.class);
+
+            semanticLinkManager.enrichWithSemanticContext(physicalEntity, sContext);
+
+            verify(mockSemanticLinkingClient, never()).getDataCategoryByNameAndNamespaceUuid(eq("unknown:SomeConcept"),
+                            anyString());
+            verify(mockSemanticLinkingClient, never()).getDataCategoryByNameAndNamespaceUuid(eq("SomeConcept"),
+                            eq(defaultNs.getUuid()));
+    }
+
+    /**
+     * {@code agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md}
+     * —
+     * Feature: Namespace prefix resolution — Scenario: Ambiguous prefix (client
+     * returns no unique namespace).
+     */
+    @Test
+    void ambiguousPrefixSkipsCategoryResolution() throws IOException {
+            reset(mockSemanticLinkingClient);
+            BDLogicalNamespaceRes defaultNs = new BDLogicalNamespaceRes();
+            defaultNs.setIdentifier("https://demo.blindata.io/logical/namespaces/name/filmRentalInc#");
+            defaultNs.setUuid("film-rental-namespace-uuid");
+
+            when(mockSemanticLinkingClient.getLogicalNamespaceByIdentifier(defaultNs.getIdentifier()))
+                            .thenReturn(Optional.of(defaultNs));
+            when(mockSemanticLinkingClient.getLogicalNamespaceByPrefix("dup")).thenReturn(Optional.empty());
+
+            BDDataCategoryRes movie = new BDDataCategoryRes();
+            movie.setName("Movie");
+            movie.setNamespace(defaultNs);
+            when(mockSemanticLinkingClient.getDataCategoryByNameAndNamespaceUuid("Movie", defaultNs.getUuid()))
+                            .thenReturn(Optional.of(movie));
+
+            Map<String, Object> sContext = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_ambiguousPrefix_semanticContext.json")),
+                            Map.class);
+            BDPhysicalEntityRes physicalEntity = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_ambiguousPrefix_rawPhysicalEntity.json")),
+                            BDPhysicalEntityRes.class);
+
+            semanticLinkManager.enrichWithSemanticContext(physicalEntity, sContext);
+
+            verify(mockSemanticLinkingClient, never()).getDataCategoryByNameAndNamespaceUuid(eq("AmbiguousConcept"),
+                            anyString());
+    }
+
+    /**
+     * {@code agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md} —
+     * Feature: Leading bracket concept with namespace prefix — Scenario: Default
+     * {@code s-type} with prefix resolves root concept in that namespace.
+     */
+    @Test
+    void sTypeWithNamespacePrefixResolvesRootConceptInPrefixedNamespace() throws IOException {
+            reset(mockSemanticLinkingClient);
+            BDLogicalNamespaceRes defaultNs = new BDLogicalNamespaceRes();
+            defaultNs.setIdentifier("https://demo.blindata.io/logical/namespaces/name/filmRentalInc#");
+            defaultNs.setUuid("film-rental-namespace-uuid");
+
+            BDLogicalNamespaceRes otherNs = new BDLogicalNamespaceRes();
+            otherNs.setUuid("other-namespace-uuid");
+            otherNs.setPrefix("other");
+
+            when(mockSemanticLinkingClient.getLogicalNamespaceByIdentifier(defaultNs.getIdentifier()))
+                            .thenReturn(Optional.of(defaultNs));
+            when(mockSemanticLinkingClient.getLogicalNamespaceByPrefix("other")).thenReturn(Optional.of(otherNs));
+
+            BDDataCategoryRes conceptB = new BDDataCategoryRes();
+            conceptB.setName("ConceptB");
+            conceptB.setNamespace(otherNs);
+            when(mockSemanticLinkingClient.getDataCategoryByNameAndNamespaceUuid("ConceptB", otherNs.getUuid()))
+                            .thenReturn(Optional.of(conceptB));
+
+            BDLogicalFieldSemanticLinkRes resolvedLink = new BDLogicalFieldSemanticLinkRes();
+            when(mockSemanticLinkingClient.getSemanticLinkElements(anyString(), anyString())).thenReturn(resolvedLink);
+
+            Map<String, Object> sContext = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_sTypePrefixed_semanticContext.json")),
+                            Map.class);
+            BDPhysicalEntityRes physicalEntity = objectMapper.readValue(
+                            Resources.toByteArray(getClass()
+                                            .getResource("testSemanticLinking_sTypePrefixed_rawPhysicalEntity.json")),
+                            BDPhysicalEntityRes.class);
+
+            semanticLinkManager.enrichWithSemanticContext(physicalEntity, sContext);
+
+            verify(mockSemanticLinkingClient, org.mockito.Mockito.times(2))
+                            .getDataCategoryByNameAndNamespaceUuid("ConceptB", otherNs.getUuid());
+            verify(mockSemanticLinkingClient, never()).getDataCategoryByNameAndNamespaceUuid(eq("other:ConceptB"),
+                            anyString());
+            verify(mockSemanticLinkingClient).getSemanticLinkElements(
+                            "[other:ConceptB].other:attribute2FromConceptB",
+                            defaultNs.getIdentifier());
+    }
+
+    /**
+     * {@code agentspecs/specs/semantic_linking/prefixed_concept_resolution/spec.md} — Non-regression: Stock /
+     * luxury-style relative paths (e.g. refersTo with {@code lux:ProductSku} segments).
+     */
     @Test
     void testSemanticPathResolutionWithStockContext() {
-        // Test the specific case mentioned in the requirement
+        reset(mockSemanticLinkingClient);
         Map<String, Object> sContext = Map.of(
                 "s-base", "https://demo.blindata.io/logical/namespaces/name/logistics#",
                 "s-type", "[Stock]",
@@ -116,6 +360,7 @@ class SemanticLinkManagerTest {
         verify(mockSemanticLinkingClient).getSemanticLinkElements("[Stock].reservedQuantity", "https://demo.blindata.io/logical/namespaces/name/logistics#");
         verify(mockSemanticLinkingClient).getSemanticLinkElements("[Stock].availableQuantity", "https://demo.blindata.io/logical/namespaces/name/logistics#");
         verify(mockSemanticLinkingClient).getSemanticLinkElements("[Stock].stockDatetime", "https://demo.blindata.io/logical/namespaces/name/logistics#");
+        verify(mockSemanticLinkingClient, never()).getLogicalNamespaceByPrefix(anyString());
     }
 
     private void setUpMocks() throws IOException {
@@ -145,6 +390,9 @@ class SemanticLinkManagerTest {
 
         lenient().when(mockSemanticLinkingClient.getSemanticLinkElements(anyString(), anyString()))
                 .thenAnswer(invocation -> semanticLinkElements.get(invocation.getArgument(0)));
+
+        lenient().when(mockSemanticLinkingClient.getLogicalNamespaceByPrefix(anyString()))
+                        .thenReturn(Optional.empty());
     }
 
     private BDPhysicalFieldRes createPhysicalField(String name) {

--- a/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/validator/controllers/BlindataValidatorControllerIT.java
+++ b/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/validator/controllers/BlindataValidatorControllerIT.java
@@ -61,6 +61,7 @@ class BlindataValidatorControllerIT extends ObserverBlindataAppIT {
                 bdSystemClient,
                 odmRegistryClient
         );
+        lenient().when(bdSemanticLinkingClient.getLogicalNamespaceByPrefix(any())).thenReturn(Optional.empty());
     }
 
     @Test

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_ambiguousPrefix_rawPhysicalEntity.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_ambiguousPrefix_rawPhysicalEntity.json
@@ -1,0 +1,17 @@
+{
+  "system": {
+    "name": "PostgreSQL - Film Rental Inc.",
+    "description": "Test",
+    "technology": "PostgreSQL"
+  },
+  "schema": "demo",
+  "name": "ambiguous_prefix_demo",
+  "tableType": "BASE_TABLE",
+  "physicalFields": [
+    {
+      "name": "dup_field",
+      "type": "varchar",
+      "ordinalPosition": 1
+    }
+  ]
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_ambiguousPrefix_semanticContext.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_ambiguousPrefix_semanticContext.json
@@ -1,0 +1,5 @@
+{
+  "s-base": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+  "s-type": "[Movie]",
+  "dup_field": "[dup:AmbiguousConcept].dup:attr"
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_mockedBlindataResponses_namespace.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_mockedBlindataResponses_namespace.json
@@ -1,5 +1,6 @@
 {
   "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#": {
+    "uuid": "film-rental-namespace-test-uuid",
     "name": "FilmRentalInc",
     "displayName": "Film Rental Inc",
     "identifier": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_expectedPhysicalEntity.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_expectedPhysicalEntity.json
@@ -1,0 +1,66 @@
+{
+  "system": {
+    "name": "PostgreSQL - Film Rental Inc.",
+    "description": "The Film Rental Inc organization's operational database",
+    "technology": "PostgreSQL"
+  },
+  "schema": "demo",
+  "name": "prefixed_concept_demo",
+  "description": "Table used to validate prefixed root concept resolution.",
+  "tableType": "BASE_TABLE",
+  "physicalFields": [
+    {
+      "name": "cross_field",
+      "type": "varchar",
+      "ordinalPosition": 1,
+      "logicalFields": [
+        {
+          "semanticLink": {
+            "defaultNamespaceIdentifier": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+            "semanticLinkString": "[other:ConceptB].other:attribute2FromConceptB",
+            "semanticLinkElements": [
+              {
+                "sequenceId": 1,
+                "resourceType": "DATA_CATEGORY",
+                "resourceName": "ConceptB",
+                "ordinalPosition": 0
+              },
+              {
+                "sequenceId": 2,
+                "resourceType": "LOGICAL_FIELD",
+                "resourceName": "attribute2FromConceptB",
+                "ordinalPosition": 1
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "dataCategories": [
+    {
+      "namespace": {
+        "name": "FilmRentalInc",
+        "displayName": "Film Rental Inc",
+        "identifier": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+        "prefix": "fri",
+        "description": "Namespace for the business ontology of Film Rental Inc"
+      },
+      "name": "Movie",
+      "displayName": "Movie",
+      "description": "Movie data such as title, release year, length, rating, etc."
+    },
+    {
+      "namespace": {
+        "name": "OtherOntology",
+        "displayName": "Other ontology",
+        "identifier": "https://demo.blindata.io/logical/namespaces/name/otherOntology#",
+        "prefix": "other",
+        "description": "Separate logical namespace reached via prefix other"
+      },
+      "name": "ConceptB",
+      "displayName": "Concept B",
+      "description": "Concept used for cross-namespace prefixed path tests."
+    }
+  ]
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_mockedBlindataResponses_semanticLinkElements.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_mockedBlindataResponses_semanticLinkElements.json
@@ -1,0 +1,22 @@
+{
+  "[other:ConceptB].other:attribute2FromConceptB": {
+    "semanticLink": {
+      "defaultNamespaceIdentifier": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+      "semanticLinkString": "[other:ConceptB].other:attribute2FromConceptB",
+      "semanticLinkElements": [
+        {
+          "sequenceId": 1,
+          "resourceType": "DATA_CATEGORY",
+          "resourceName": "ConceptB",
+          "ordinalPosition": 0
+        },
+        {
+          "sequenceId": 2,
+          "resourceType": "LOGICAL_FIELD",
+          "resourceName": "attribute2FromConceptB",
+          "ordinalPosition": 1
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_rawPhysicalEntity.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_rawPhysicalEntity.json
@@ -1,0 +1,18 @@
+{
+  "system": {
+    "name": "PostgreSQL - Film Rental Inc.",
+    "description": "The Film Rental Inc organization's operational database",
+    "technology": "PostgreSQL"
+  },
+  "schema": "demo",
+  "name": "prefixed_concept_demo",
+  "description": "Table used to validate prefixed root concept resolution.",
+  "tableType": "BASE_TABLE",
+  "physicalFields": [
+    {
+      "name": "cross_field",
+      "type": "varchar",
+      "ordinalPosition": 1
+    }
+  ]
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_semanticContext.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_prefixedConcept_semanticContext.json
@@ -1,0 +1,5 @@
+{
+  "s-base": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+  "s-type": "[Movie]",
+  "cross_field": "[other:ConceptB].other:attribute2FromConceptB"
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_sTypePrefixed_rawPhysicalEntity.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_sTypePrefixed_rawPhysicalEntity.json
@@ -1,0 +1,17 @@
+{
+  "system": {
+    "name": "PostgreSQL - Film Rental Inc.",
+    "description": "Test",
+    "technology": "PostgreSQL"
+  },
+  "schema": "demo",
+  "name": "stype_prefixed_demo",
+  "tableType": "BASE_TABLE",
+  "physicalFields": [
+    {
+      "name": "field1",
+      "type": "varchar",
+      "ordinalPosition": 1
+    }
+  ]
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_sTypePrefixed_semanticContext.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_sTypePrefixed_semanticContext.json
@@ -1,0 +1,5 @@
+{
+  "s-base": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+  "s-type": "[other:ConceptB]",
+  "field1": "other:attribute2FromConceptB"
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_unknownPrefix_rawPhysicalEntity.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_unknownPrefix_rawPhysicalEntity.json
@@ -1,0 +1,17 @@
+{
+  "system": {
+    "name": "PostgreSQL - Film Rental Inc.",
+    "description": "Test",
+    "technology": "PostgreSQL"
+  },
+  "schema": "demo",
+  "name": "unknown_prefix_demo",
+  "tableType": "BASE_TABLE",
+  "physicalFields": [
+    {
+      "name": "orphan_field",
+      "type": "varchar",
+      "ordinalPosition": 1
+    }
+  ]
+}

--- a/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_unknownPrefix_semanticContext.json
+++ b/src/test/resources/org/opendatamesh/platform/up/metaservice/blindata/schema_analyzers/semanticlinking/testSemanticLinking_unknownPrefix_semanticContext.json
@@ -1,0 +1,5 @@
+{
+  "s-base": "https://demo.blindata.io/logical/namespaces/name/filmRentalInc#",
+  "s-type": "[Movie]",
+  "orphan_field": "[unknown:SomeConcept].unknown:attr"
+}


### PR DESCRIPTION
…space resolution

- Introduced `README.md` for AgentSpecs detailing the structure and workflow for specifications and proposals.
- Added `GENERIC-CRUD-GUIDELINES.md` and `USE_CASE_IMPLEMENTATION.md` to provide architectural guidelines for CRUD services and use case implementations.
- Created a new spec for prefixed concept resolution in `s-context` to define behavior for namespace prefix handling.
- Implemented methods in `BdClientImpl` and `BdSemanticLinkingClient` for logical namespace retrieval by prefix.
- Enhanced `SemanticLinkManagerImpl` to support prefixed concept resolution and updated related tests for non-regression.
- Added new test cases to validate the behavior of prefixed root concepts and ambiguous prefixes.