### PR TITLE
feat: implement quality check name/code conflict detection during upload

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -89,6 +89,7 @@ The validation system performs comprehensive checks across multiple areas of the
 - **Missing Quality Check Code**: Ensures quality checks have a code defined
 - **Invalid Quality Object**: Validates quality object structure and properties
 - **Reference Quality Checks**: Handles quality checks that are references to other definitions
+- **Quality Check Name/Code Conflict (`[#121]`)**: Detects when an incoming Quality Check would collide with an existing Blindata check in the same suite that has the same display name but a different code (typical after renaming `quality.name` without aligning `customProperties.displayName` or using a stable `quality.id`). See [Validator Error Codes](./validator-error-codes.md).
 - **Missing Issue Policy Information**: Validates issue policies have required fields:
   - Policy name
   - Policy type

--- a/docs/validator-error-codes.md
+++ b/docs/validator-error-codes.md
@@ -119,6 +119,9 @@ When the Blindata policy validator evaluates a data product, it logs warning mes
 | `[#42]` | %s Quality Check: %s is a reference and does not have a main declaration. |
 | `[#43]` | %s Missing info fields on data product. |
 | `[#44]` | %s Missing interface components on data product: %s. |
+| `[#121]` | %s Quality Check name/code conflict: incoming code='%s' name='%s' conflicts with existing Blindata code='%s' name='%s' in the same suite. Update customProperties.displayName (or the mapped display name) to match the renamed quality, or use a stable quality.id so the code no longer tracks quality.name. |
+
+`[#121]` is emitted when the observer is about to upload a Quality Check whose Blindata **display name** already exists in the same Quality Suite under a **different code**. This typically happens after renaming `quality.name` without updating `customProperties.displayName` (and without a stable `quality.id`). Blindata upserts by code and enforces unique names per suite, so the create would otherwise fail with an opaque conflict. The validator collects this warning and fails policy evaluation when Blindata validation is active.
 
 ### Quality check validation (thresholds and strategies)
 

--- a/spdd/analysis/BDMD-5357-202607221119-[Analysis]-quality-check-name-code-conflict.md
+++ b/spdd/analysis/BDMD-5357-202607221119-[Analysis]-quality-check-name-code-conflict.md
@@ -1,0 +1,123 @@
+# SPDD Analysis: Quality Check Name/Code Conflict on Upload
+
+## Original Business Requirement
+
+When the name field of a quality object is modified in a descriptor without updating its corresponding displayName, Blindata interprets the Quality Check as a new entity during upload.
+
+This happens because the generated code (derived from the domain, DP name, and field name) changes, causing the upload process to create a new Quality Check instead of updating the existing one. The operation then fails because two Quality Checks cannot exist with the same name.
+
+Problem
+Current behavior:
+
+A user changes the quality.name field in a descriptor but the displayName is left unchanged.
+During upload, the generated quality check code changes.
+Blindata treats the Quality Check as a new resource.
+A conflict occurs because a Quality Check with the same name already exists.
+
+Solution:
+For each quality check, verify that it does not exist a quality check on Blindata with the same name (in the same suite) but with different code. The error should be clearly understandable, addressing the two quality checks that generate the problem.
+
+## Domain Concept Identification
+
+### Domain Concept Identification
+
+#### Existing Concepts (from codebase)
+
+- **Quality object (descriptor)**: ODCS / Datastore API quality annotation on an entity or field (`name`, optional `id`, optional `customProperties.displayName`). Source of identity inputs for Blindata mapping.
+- **Quality Check (observer internal + Blindata KQI)**: Upload payload entity with `code` (technical identity used by Blindata import upsert) and `name` (display name; unique per Quality Suite on Blindata). Mapped from the quality object in `DataStoreApiStandardDefinitionVisitorImpl`.
+- **Quality Suite**: Per–data-product container; `code` = `{domain} - {dataProductName}`; `name` uses data product displayName when set. All extracted checks for a product land in this suite.
+- **Quality Check code composition**: Short segment = `quality.id` when present, else `quality.name`; then prefixed as `{suiteCode} - {shortSegment}` before upload (`QualityUpload.addQualitySuiteCodeToQualityChecksCode`).
+- **Quality Check display name**: Priority `customProperties.displayName` > `quality.name` > `quality.id` (`qualityCheckDisplayName`). This becomes Blindata `QualityCheck.name`.
+- **QUALITY_UPLOAD use case**: Extracts checks from ports, validates locally (warnings only for missing fields/thresholds), builds suite, then calls Blindata `import-objects`. Upsert on Blindata is **by code within suite**; create fails if another check already has the same **name in the suite**.
+- **Blindata name uniqueness (suite-scoped)**: Blindata enforces at most one Quality Check with a given `name` inside a given suite; code is also unique. This is the constraint that surfaces as a conflict today.
+- **BdQualityClient / search option DTOs**: Client currently only uploads; `QualityCheckSearchOptions` and `QualitySuitesSearchOptions` already exist in the observer but are unused—no pre-upload lookup of existing Blindata checks/suites.
+
+#### New Concepts Required
+
+- **Name/code identity conflict**: Situation where a descriptor-derived Quality Check targets a Blindata suite that already has a check with the **same name** but a **different code**—typically after renaming `quality.name` without updating `customProperties.displayName` (and without a stable `quality.id`).
+- **Pre-upload conflict guard**: Explicit verification step that detects the name/code mismatch and emits a clear warning identifying **both** the incoming check and the existing Blindata check—consumed by the observer validator.
+- **Blindata Quality Suite/Check lookup capability** (conceptual): Ability for the observer to resolve the suite and inspect existing checks by name/code within that suite—search DTOs exist; outbound port/client methods to use them do not yet.
+
+#### Key Business Rules
+
+- **Upsert identity is code, not name**: Blindata import matches existing checks by `code` (+ suite). A code change is treated as a new check.
+- **Display name uniqueness within suite**: Two checks in the same suite cannot share the same `name`.
+- **When `id` is absent, `name` drives the code segment**: Renaming `quality.name` changes Blindata `code` while leaving Blindata `name` unchanged if `customProperties.displayName` is set and unchanged.
+- **When `id` is present, renaming `name` alone does not change code**: Identity is stable via `id`; this conflict path is primarily for rules without `id` (or when `id` itself also changes).
+- **Guard must compare within the same suite**: Cross-suite same names are out of scope for this uniqueness rule.
+- **Warning must identify both parties**: Message should surface the conflicting pair (incoming code/name vs existing Blindata code/name) so users understand they renamed the technical name without aligning display identity.
+- **Remediation guidance in the warning**: Suggest **both** updating `customProperties.displayName` (or the mapped display name) **or** using a stable `quality.id` so code no longer tracks `name`.
+- **Failure mode is warn (validator-driven)**: Emit via `getUseCaseLogger().warn(...)` (same pattern as existing quality validations). In dry-run, `ValidatorUseCaseLogger` collects warnings and the observer validator sets `evaluationResult=false`—sufficient to block publish when the Blindata validator policy is active/blocking. Do **not** throw `UseCaseExecutionException` for this conflict.
+- **Suite absent → no-op**: If the Quality Suite does not yet exist on Blindata (first-time upload), skip the guard; no collision is possible.
+- **Collect all conflicts**: Detect and report **all** name/code conflicts in the upload (not fail-fast on the first); surface them together so the validator rawError lists every conflicting pair.
+
+## Strategic Approach
+
+### Strategic Approach
+
+#### Solution Direction
+
+Extend the **QUALITY_UPLOAD** flow so that, after quality checks are extracted and suite-prefixed codes are assigned, the observer **looks up the corresponding Quality Suite on Blindata** (when it already exists) and **detects any incoming check whose `name` already exists in that suite under a different `code`**. On detection, log clear warning(s) that name both the descriptor-side check and the existing Blindata check, suggest updating displayName **or** using a stable `quality.id`, and **collect all** such conflicts for the validator. If the suite does not exist yet, the guard is a no-op. Primary enforcement is through the **observer validator** (dry-run path): warnings fail policy evaluation. Leverage existing use-case layering (outbound port + `BdQualityClient`), existing search-option resources, and Blindata’s suite-scoped name uniqueness semantics—do not change Blindata upsert identity or descriptor mapping of code/name.
+
+High-level data flow: descriptor ports → extract Quality Checks → build suite & prefix codes → **conflict guard against Blindata suite contents (collect all conflicts → warn)** → upload via `import-objects` (upload path continues; validator dry-run surfaces the warns as policy failure).
+
+#### Key Design Decisions
+
+- **Pre-upload guard vs. rely on Blindata conflict**: Blindata already rejects the create, but the message does not explain the rename scenario or identify both codes. → **Recommend** observer-side detection with an explicit warning before Blindata’s opaque API conflict.
+- **Lookup strategy**: Resolve suite by suite `code`, then find checks in that suite whose `name` equals the incoming name and whose `code` differs. Search options support suite UUID + text search (name LIKE / code equality on Blindata); exact name match must be applied after retrieval to avoid false positives. → **Recommend** suite resolve + suite-scoped search/filter with exact name equality.
+- **Failure mode**: → **Decided: warn**. A clear `warn` is sufficient because the observer validator collects use-case warnings via `ValidatorUseCaseLogger` and fails the policy evaluation when any warning is present. Hard `UseCaseExecutionException` is not required for this scenario.
+- **Dry-run / validator**: → **Decided: in scope as the enforcement path**. Dry-run outbound port no-ops `uploadQuality` but must still run the conflict guard with read-only Blindata calls so validation catches the issue before publish.
+- **Suite not yet on Blindata**: → **Decided: no-op**. First-time upload cannot collide; skip the guard when the suite is absent.
+- **Multiple conflicts**: → **Decided: collect all**. Report every conflicting pair (together / as multiple warns collected by the validator), not stop at the first.
+- **Remediation messaging**: → **Decided: suggest both** updating `customProperties.displayName` and introducing/keeping a stable `quality.id`.
+- **Scope of mapping change**: Fixing by always deriving Blindata `name` from `quality.name` (ignoring displayName) or always requiring `id` would change mapping contracts and break intentional display overrides. → **Recommend** keeping mapping as-is; add detection only.
+- **Where to place the guard**: Closest to upload orchestration in `QualityUpload` (after codes are final), with Blindata reads behind `QualityUploadBlindataOutboundPort` / `BdQualityClient`—matches existing ports pattern for issue campaigns/users; dry-run must not stub out the lookup methods.
+
+#### Alternatives Considered
+
+- **Hard-fail with `UseCaseExecutionException`**: Rejected—product decision is that a **warn** is sufficient; the observer validator turns warnings into a failed policy evaluation.
+- **Auto-heal: treat same-name as same entity and overwrite code**: Rejected—changing Blindata identity by name silently could merge unrelated checks or surprise users; ticket asks for a clear message, not remapping.
+- **Change Blindata import to upsert by name**: Rejected—cross-system identity change; out of observer scope; code remains the documented technical key.
+- **Only improve docs / require `quality.id`**: Helpful long-term but does not stop the failing path when users rename without `id`; ticket asks for runtime verification.
+- **Surface only Blindata’s existing ResourceConflictException**: Rejected—does not identify the two codes/names involved in the rename scenario.
+
+## Risk & Gap Analysis
+
+### Risk & Gap Analysis
+
+#### Requirement Ambiguities
+
+- **No numbered Acceptance Criteria**: ACs below are derived from the problem/solution text plus the clarified product decisions (warn/validator, suite no-op, collect all conflicts, dual remediation messaging).
+- **Exact meaning of “displayName”**: In the descriptor, KQI display override is `customProperties.displayName`, not a top-level `displayName`. Analysis assumes that field; confirm with reporters if needed.
+- ~~**Behavior when suite does not yet exist**~~ → **Decided: no-op** (no warn on first-time upload).
+- ~~**Multiple conflicts in one upload**~~ → **Decided: collect all** conflicting pairs for the validator output.
+- ~~**Intentional same display name, different rules**~~ → **Decided: warn is correct**; messaging suggests **both** updating displayName and using a stable `quality.id`.
+
+#### Edge Cases
+
+- **`quality.id` present**: Renaming `name` alone does not change code; conflict may not occur. Guard still valuable if `id` changes while display name stays the same.
+- **`customProperties.displayName` absent**: Blindata `name` tracks `quality.name`; renaming both code and name together usually avoids this conflict (old check orphaned by code; new check created with new name). Cleanup/`assetsCleanup` behavior may leave orphans—out of primary scope but related.
+- **Fuzzy Blindata `search`**: API matches name with LIKE; short/common names risk matching multiple checks—must exact-match on `name` after fetch.
+- **Live upload without prior validator**: Warn does not abort `QUALITY_UPLOAD`; if the descriptor bypasses the validator, Blindata may still return an opaque name conflict. Residual risk accepted given validator-first enforcement.
+- **References (`refName`)**: References are stripped before upload; guard should run on final non-reference checks only.
+- **Same conflict across ports merged by code**: Merge already collapses same short code; name/code conflict is against Blindata state, not intra-descriptor duplicates.
+- **Multiple conflicts**: All pairs are reported; validator `rawError` should list every warning so users can fix the full set in one pass.
+
+#### Technical Risks
+
+- **Missing client read APIs**: Observer can upload but cannot yet list/search suites or checks—must add read methods on `BdQualityClient` / outbound port. Search DTOs already mirror Blindata API. Dry-run must call these reads (not stub them).
+- **Performance**: N checks × Blindata lookups; mitigate by resolving suite once and loading suite checks (or batched search) rather than per-check round-trips where possible.
+- **Exact name match vs. search semantics**: Relying only on Blindata LIKE search without post-filter can false-positive or miss; design must require equality on `name` within suite.
+- **Warn delivery to validator**: Message must go through `getUseCaseLogger().warn` so `ValidatorUseCaseLogger` captures it; logging only via SLF4J would not fail policy evaluation.
+- **Concurrency**: Two parallel uploads could still race; residual risk remains at Blindata—acceptable if documented.
+
+#### Acceptance Criteria Coverage
+
+| AC# | Description                                                                                                                                                                                                   | Addressable? | Gaps/Notes                                                                 |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------- |
+| 1   | When a descriptor quality object’s `name` changes but Blindata display name (`customProperties.displayName` / mapped `name`) stays the same, the conflict is detected before Blindata’s opaque create failure | Yes          | Guard detects same-name/different-code in suite                            |
+| 2   | For each quality check, verify no Blindata check exists in the same suite with the same name and a different code                                                                                             | Yes          | Requires suite + check lookup capability                                   |
+| 3   | On conflict, emit clear warning(s) that identify both checks involved and suggest updating displayName **or** using a stable `quality.id`; collect **all** conflicts                                          | Yes          | Warn via use-case logger; aggregate for validator rawError                 |
+| 4   | Happy path: unchanged name/code or intentional name+display rename continues to upload/update by code as today                                                                                                | Yes          | Guard must not warn on matching code+name or new names                     |
+| 5   | First upload / suite absent: no false warning                                                                                                                                                                 | Yes          | **Decided:** skip guard when suite not found on Blindata                   |
+| 6   | Observer validator (dry-run) surfaces the conflict and fails policy evaluation when warnings are present                                                                                                      | Yes          | Decided: warn is the failure mode; validator collects warnings → fail eval |

--- a/spdd/norms/GENERIC-CRUD-GUIDELINES.md
+++ b/spdd/norms/GENERIC-CRUD-GUIDELINES.md
@@ -1,0 +1,119 @@
+# Generic CRUD services (template method pattern)
+
+CRUD can be implemented through a small hierarchy of abstract classes that follow the **template method** pattern: the base class defines the **algorithm** (order of steps, transactions, error handling), and subclasses supply **hooks** and **type-specific behavior** by implementing abstract methods and optionally overriding protected hook methods.
+
+---
+
+## Class hierarchy
+
+| Layer | Interface | Implementation | Purpose |
+| ----- | --------- | -------------- | ------- |
+| Entity CRUD | `GenericCrudService<T, ID>` | `GenericCrudServiceImpl<T, ID>` | Persistence for JPA entities `T` with id `ID`. |
+| + API mapping | `GenericMappedCrudService<R, T, ID>` | `GenericMappedCrudServiceImpl<R, T, ID>` | Adds REST/DTO type `R`: map `R ↔ T` and expose `*Resource` methods. |
+| + filtering | `GenericMappedAndFilteredCrudService<F, R, T, ID>` | `GenericMappedAndFilteredCrudServiceImpl<F, R, T, ID>` | Adds filter object `F` and specification-based list queries. |
+
+**Type parameters**
+
+- **`T`** — JPA entity.
+- **`ID`** — Primary key type (`Serializable`, e.g. `Long`, `String`).
+- **`R`** — API resource / DTO returned to callers.
+- **`F`** — Search or filter options used to build a JPA `Specification<T>`.
+
+Pick the **shallowest** layer that fits: if the API does not need a separate `R`, you might only extend `GenericCrudServiceImpl`. When list endpoints support query filters and you expose DTOs, use **`GenericMappedAndFilteredCrudServiceImpl`**.
+
+---
+
+## What you must implement
+
+### `GenericCrudServiceImpl<T, ID>`
+
+1. **`getRepository()`** — Return a repository that supports CRUD, paging/sorting, and JPA specifications (e.g. a type extending `CrudRepository`, `PagingAndSortingRepository`, and `JpaSpecificationExecutor`).
+
+2. **`validate(T)`** — Business and field validation before create/overwrite. Throw your domain or API-layer exceptions on failure.
+
+3. **`reconcile(T)`** — Resolve references, defaults, or denormalized state after validation and before save (e.g. load related entities by foreign key).
+
+Optional **hooks** (empty defaults; override when needed):
+
+- **Read:** `afterFindOne(T, ID)`
+- **Create:** `beforeCreation(T)`, `afterCreation(T, T)`, `afterCreationCommit(T)`
+- **Update:** `beforeOverwrite(T)`, `afterOverWrite(T, T)`, `afterOverwriteCommit(T)`
+- **Delete:** `beforeDelete(ID)`, `afterDelete(ID)`, `afterDeleteCommit(T)` (used with `deleteReturning`)
+
+**Utilities:** `exists(ID)` is protected; `checkExistenceOrThrow(ID)` and `findOne(ID)` typically throw a not-found exception when the row is missing.
+
+### `GenericMappedCrudServiceImpl<R, T, ID>`
+
+Adds mapping between API and persistence:
+
+1. **`toRes(T entity)`** — Entity → API resource.
+2. **`toEntity(R resource)`** — API resource → entity (for incoming bodies).
+
+Delegation to a dedicated mapper class is common. Mapped operations are:
+
+- `findAllResources` / `findOneResource` / `createResource` / `overwriteResource` / `deleteReturningResource`
+
+### `GenericMappedAndFilteredCrudServiceImpl<F, R, T, ID>`
+
+1. **`getSpecFromFilters(F filters)`** — Build a `Specification<T>`, often by composing smaller specs (e.g. AND-combining a list of predicates).
+
+2. **`getRepository()`** — May be declared again in this class so the implementation satisfies the abstract method from the filtered layer (same bean as in `GenericCrudServiceImpl`).
+
+**Note:** `findAllFiltered` runs `getRepository().findAll(spec, pageable)`. Override `findAll` / `findAllResources` only if you need different list behavior (for example, disabling generic pagination for a given aggregate).
+
+---
+
+## Fixed algorithm (template method)
+
+The base class fixes the **order of operations**; subclasses should not change the sequence unless they intentionally override a public method (usually avoided).
+
+**Create:** `validate` → `reconcile` → `beforeCreation` → `save` → `afterCreation` → (after transaction) → `afterCreationCommit`
+
+**Overwrite:** `validate` → existence check → `reconcile` → `beforeOverwrite` → `save` → `afterOverWrite` → `afterOverwriteCommit`
+
+**Delete:** existence check → `beforeDelete` → `deleteById` → `afterDelete`
+
+**`deleteReturning`:** `findOne` → map with provided `Function` → `delete` → `afterDeleteCommit`
+
+Create/overwrite/delete bodies typically use Spring’s **`TransactionTemplate`** so the transactional boundary is explicit inside the generic implementation. Read paths may use a small **`TransactionHandler`** (or equivalent) with `@Transactional` for mapped/filtered reads so lazy loading and mapping run inside a transactional boundary when needed.
+
+---
+
+## Transactions: two mechanisms
+
+- **`TransactionTemplate`** (in `GenericCrudServiceImpl`): used for writes in the generic CRUD flow.
+- **`TransactionHandler`** (or similar) in mapped layers: transactional wrapper for read operations that map entities to resources.
+
+When one service calls another (e.g. loading a related entity in `reconcile`), use the existing service API and stay aware of transaction boundaries if you need atomicity across multiple aggregates.
+
+---
+
+## Controllers and public API
+
+- Prefer **`…Resource` methods** for HTTP adapters so the layer works with `R`, not entities.
+- If path parameters must **override** fields in the body (e.g. id in URL vs body), override the `*Resource` method, set the field from the path, then call `super`.
+
+---
+
+## Example shape (conceptual)
+
+A typical filtered, mapped service:
+
+- Extends `GenericMappedAndFilteredCrudServiceImpl<MySearchOptions, MyResource, MyEntity, MyIdType>`.
+- Implements `validate`, `reconcile`, `getSpecFromFilters`, `getRepository`, `toRes`, `toEntity`.
+- Uses `beforeCreation` / `beforeOverwrite` for rules that depend on persisted state (e.g. uniqueness excluding the current row).
+- Builds `Specification` instances from filter fields, composed with AND/OR as needed.
+
+---
+
+## Design tips
+
+1. **Keep `validate` focused** on invariants, format, and required fields; use **`reconcile`** for loading associations and fixing navigable graphs before `save`.
+
+2. **Use hooks** for database-dependent rules (uniqueness excluding self, side effects) so they run in the same transaction as `save` / `delete`.
+
+3. **Repository** must support paging and specifications if you use the filtered base class; static nested `Spec` helpers on the repository are a common style.
+
+4. **Throw** exceptions that your global handler maps to HTTP status codes consistently.
+
+5. If an aggregate **must not** support generic `findAll(Pageable)`, override those methods and throw an explicit “not supported” (or equivalent) with a clear message.

--- a/spdd/norms/README.md
+++ b/spdd/norms/README.md
@@ -1,0 +1,228 @@
+# Code norms (`agentspecs/norms`)
+
+This package holds **architectural and implementation norms** for Blindata backend work. Use it when generating or implementing features so new code matches agreed patterns.
+
+**Primary consumer:** the **`/spdd-reasons-canvas`** command (REASONS-Canvas **N — Norms** section). Reference this README (and the norm files it points to) so generated prompts include concrete, checkable standards—not generic placeholders.
+
+---
+
+## How to use with `/spdd-reasons-canvas`
+
+When running the command, include this package in the input so the agent loads norms before filling **## Norms**:
+
+```
+/spdd-reasons-canvas @agentspecs/norms/README.md <your business context or @requirement file>
+```
+
+**Agent workflow (Norms stage):**
+
+1. **Read** this README and every norm file listed under [Norm files](#norm-files) that applies to the work (see [Which norm file applies?](#which-norm-file-applies)).
+2. **Infer scope** from business context: CRUD-only, use-case/orchestration, or both.
+3. **Populate `## Norms`** in the output prompt with:
+   - Cross-cutting items from [Cross-cutting code norms](#cross-cutting-code-norms) (always relevant for backend features).
+   - Norms from the applicable dedicated files (summarized below; cite file names so implementers can open the full guide).
+4. **Do not** paste entire norm documents into the canvas—distill **actionable, verifiable** bullets (naming, packages, annotations, boundaries, testing).
+5. Keep **Safeguards** separate: norms = *how to build*; safeguards = *boundaries and non-negotiables* from the requirement.
+
+**Output shape** (align with the command template):
+
+```markdown
+## Norms
+1. Annotation standards: …
+2. Dependency injection: …
+3. Exception handling: …
+4. Data validation: …
+5. Logging: …
+6. Documentation standards: …
+7. [Feature-specific] Use-case boundaries: … (when applicable)
+8. [Feature-specific] CRUD template-method hooks: … (when applicable)
+```
+
+---
+
+## Which norm file applies?
+
+| You are building… | Read |
+|-------------------|------|
+| REST endpoint with orchestration, ports, commands, presenters (non-trivial workflow) | [`USE_CASE_IMPLEMENTATION.md`](./USE_CASE_IMPLEMENTATION.md) |
+| Entity CRUD with optional DTO mapping and/or filtered list APIs | [`GENERIC-CRUD-GUIDELINES.md`](./GENERIC-CRUD-GUIDELINES.md) |
+| Both (e.g. use case that delegates persistence to core CRUD services) | **Both** — use cases call core services **via outbound ports**, not directly from the use case class |
+
+---
+
+## Cross-cutting code norms
+
+These apply to most backend work surfaced through REASONS-Canvas. Feature-specific norms in the dedicated files **extend** this list; they do not replace it.
+
+### Layering and responsibilities
+
+- **Thin HTTP adapter:** Controllers map HTTP only; no business rules. Services (use-case service or CRUD service) own orchestration and mapping at the application boundary.
+- **Domain inside the use case package:** Commands and presenters use **entities, value types, or small domain records**—never REST `*Res` types inside `...services.usecases.*`.
+- **Core vs use case:** Reusable CRUD/query logic lives in `...services.core.*` (or equivalent). Use cases reach core only through **outbound port implementations**, not by injecting core services into the use case class.
+- **Pick the shallowest CRUD base** that fits (`GenericCrudServiceImpl` → mapped → filtered); do not add filter/mapping layers without need.
+
+### Spring and dependency injection
+
+- **`@RestController`** on `*UseCaseController` with `@RequestMapping`, `produces = APPLICATION_JSON_VALUE`.
+- **`@Service`** on `*UseCasesService` and concrete CRUD service subclasses.
+- **`@Component`** on the use-case **factory only** in that slice; outbound port impls are **plain Java** (`new` in the factory).
+- **No Spring stereotypes** on use case classes or `*OutboundPortImpl`.
+- **Constructor injection** for factories and services; use cases receive dependencies via factory constructor wiring.
+
+### REST resources and OpenAPI
+
+- Request/response DTOs under `rest.v2.resources...` with naming `*CommandRes`, `*ResultRes` (and related `*Res`).
+- Document controllers with `@Tag`, `@Operation`, `@ApiResponses`, `@Parameter`; `@Schema` on DTO fields where useful; `@Hidden` for non-public endpoints.
+- **Mappers** (`rest.v2.resources` / MapStruct) convert `*Res` ↔ entities in the **use cases service** (or CRUD `toRes` / `toEntity`), not in controllers or use case classes.
+
+### Exceptions and API errors
+
+- Throw domain/API exceptions (e.g. `BadRequestException`) for invalid state from use cases and validation hooks.
+- **Business exceptions:** extend `RuntimeException` or a shared `BusinessException` base; include **`errorCode`** and **`errorMessage`**; provide multiple constructors; classify by business domain.
+- **Unified HTTP errors:** `GlobalExceptionHandler` (`@RestControllerAdvice`) maps business, validation, and system exceptions to a consistent **`ErrorResponse`** DTO; do not leak sensitive internals in messages.
+- CRUD **`validate` / `reconcile` / hooks** throw exceptions that the global handler maps to stable HTTP status codes.
+
+### Data validation
+
+- **CRUD:** `validate(T)` for invariants and required fields; `reconcile(T)` for loading associations and fixing graphs before save.
+- **Use cases:** validate the command early in `execute()`; fail fast with clear exceptions.
+- Path parameters that must override body fields: override the `*Resource` method on the CRUD service, set the field, then call `super`.
+
+### Transactions
+
+- **Use cases:** use shared `TransactionalOutboundPort` (`doInTransaction`, `doInTransactionWithResults`) for atomic work—do not reimplement transaction plumbing per use case.
+- **CRUD:** template methods in `GenericCrudServiceImpl` use `TransactionTemplate` for writes; mapped reads may use a transactional wrapper when mapping touches lazy associations.
+
+### Logging
+
+- SLF4J with class-level logger; log at **info/warn** for business-significant steps and failures; **never** log secrets or credentials.
+- Prefer structured context (identifiers, operation phase) consistent with surrounding modules.
+
+### Testing
+
+- **Use cases:** add or extend `*UseCaseControllerIT` for full-stack verification of new routes.
+- **CRUD / ports:** unit-test complex `validate`/`reconcile`/spec builders or port adapters where payoff is high.
+- Trace tests back to requirements when generated from a spec (comment referencing scenario or requirement id).
+
+### Documentation in code
+
+- Keep public API documented via OpenAPI annotations; avoid redundant Javadoc on obvious getters/setters.
+- Package-private use case classes and port types unless wider visibility is required.
+
+---
+
+## Norm files
+
+### [`USE_CASE_IMPLEMENTATION.md`](./USE_CASE_IMPLEMENTATION.md)
+
+**Purpose:** Hexagonal-style use case flow from HTTP through application orchestration to outbound adapters.
+
+**When to apply:** New or changed behavior that is more than CRUD—initialization flows, multi-step orchestration, validation + persistence + side effects (notifications, etc.).
+
+**Flow (must appear in Structure / Operations when relevant):**
+
+```
+HTTP → *UseCaseController → *UseCasesService → *Factory → UseCase
+  → OutboundPort(s) → *OutboundPortImpl → core services / clients
+```
+
+**Hard boundaries (non-negotiable in generated prompts):**
+
+| Layer | Rule |
+|-------|------|
+| `rest.v2.resources` `*Res` | Only controller + use cases service; **never** in `...services.usecases.*` |
+| Command | Domain types only (entities, UUIDs, enums, small domain records) |
+| Presenter | Domain result types only; service maps to `*ResultRes` |
+| Use case class | Implements `UseCase`; package-private; **no** Spring annotations; **no** `@Autowired` |
+| Factory | Sole `@Component` in the slice; `build...(Command, Presenter)` returns `UseCase`; wires ports with `new` |
+| `*OutboundPortImpl` | Plain Java; collaborators via constructor from factory |
+
+**Package layout per use case** (`...services.usecases.<name>`):
+
+| Artifact | Naming / role |
+|----------|----------------|
+| `<Name>.java` | Use case; `execute()` orchestration |
+| `<Name>Command.java` | Input record |
+| `<Name>Presenter.java` | Output boundary interface |
+| `<Name>Factory.java` | Composition root |
+| `*OutboundPort.java` / `*OutboundPortImpl.java` | Port + adapter |
+
+**Shared utilities:** `utils.usecases.UseCase`, `TransactionalOutboundPort` (implemented by `DefaultTransactionalOutboundPortImpl`).
+
+**Checklist for new use cases** (use in Operations section as task order):
+
+1. Command + presenter (domain only) in `usecases.<name>`.
+2. Outbound port interfaces + plain impls.
+3. `@Component` factory with `new` for impls.
+4. `*UseCasesService` method: `*CommandRes` → command, factory + `execute()`, presenter → `*ResultRes`.
+5. `*CommandRes` / `*ResultRes` under `rest.v2.resources...usecases...`.
+6. `*UseCaseController` endpoint + OpenAPI.
+7. `*UseCaseControllerIT`.
+
+**Full detail:** [USE_CASE_IMPLEMENTATION.md](./USE_CASE_IMPLEMENTATION.md)
+
+---
+
+### [`GENERIC-CRUD-GUIDELINES.md`](./GENERIC-CRUD-GUIDELINES.md)
+
+**Purpose:** Template-method CRUD for JPA entities with optional API mapping and specification-based filtering.
+
+**When to apply:** Standard create/read/update/delete (and filtered lists) on aggregates exposed as REST resources.
+
+**Class hierarchy (choose one):**
+
+| Layer | Types | Use when |
+|-------|--------|----------|
+| Entity CRUD | `GenericCrudService<T, ID>` / `GenericCrudServiceImpl` | Persistence only, no separate API type `R` |
+| + mapping | `GenericMappedCrudService<R, T, ID>` / `...Impl` | Expose `*Resource` methods (`findOneResource`, `createResource`, …) |
+| + filtering | `GenericMappedAndFilteredCrudService<F, R, T, ID>` / `...Impl` | List endpoints with filter object `F` → `Specification<T>` |
+
+**Must implement (subclass):**
+
+- `getRepository()` — CRUD + paging/sort + `JpaSpecificationExecutor` when filtered.
+- `validate(T)` — invariants before create/overwrite.
+- `reconcile(T)` — associations and defaults before save.
+- Mapped: `toRes(T)`, `toEntity(R)`.
+- Filtered: `getSpecFromFilters(F)` — compose specs (often AND).
+
+**Template method order (do not reorder without overriding intentionally):**
+
+- **Create:** `validate` → `reconcile` → `beforeCreation` → `save` → `afterCreation` → `afterCreationCommit`
+- **Overwrite:** `validate` → existence → `reconcile` → `beforeOverwrite` → `save` → `afterOverWrite` → `afterOverwriteCommit`
+- **Delete:** existence → `beforeDelete` → `deleteById` → `afterDelete`
+
+**Hooks (override when needed):** `afterFindOne`, `beforeCreation`, `afterCreation`, `beforeOverwrite`, `afterOverWrite`, `beforeDelete`, `afterDelete`, `afterDeleteCommit`, etc.
+
+**Controllers:** Prefer `*Resource` methods; path id overrides body in overridden `*Resource` methods.
+
+**Design tips for Norms / Safeguards:**
+
+- Keep `validate` strict; put association loading in `reconcile`.
+- Use hooks for DB-dependent rules (uniqueness excluding self) in the same transaction as `save`.
+- If `findAll(Pageable)` is not allowed for an aggregate, override and throw explicit not-supported.
+- Repository must support specifications when using the filtered base class.
+
+**Full detail:** [GENERIC-CRUD-GUIDELINES.md](./GENERIC-CRUD-GUIDELINES.md)
+
+---
+
+## Combining norms in one feature
+
+Typical pattern when a canvas covers both CRUD and a workflow:
+
+1. **Structure:** CRUD service in core; use case package with ports whose impls delegate to `*CrudService` / `*Service`.
+2. **Operations:** CRUD tasks follow hook and `*Resource` naming; use case tasks follow the 7-step checklist.
+3. **Norms:** Merge cross-cutting list + CRUD template-method bullets + use-case boundary table.
+4. **Safeguards:** Requirement-specific constraints (performance, security, idempotency)—not duplicated from norm files unless they encode a global rule.
+
+---
+
+## Package index
+
+| File | Topic |
+|------|--------|
+| [`README.md`](./README.md) | This index, cross-cutting norms, SPDD integration |
+| [`USE_CASE_IMPLEMENTATION.md`](./USE_CASE_IMPLEMENTATION.md) | Use case hexagon, REST adapter, ports, factory, testing |
+| [`GENERIC-CRUD-GUIDELINES.md`](./GENERIC-CRUD-GUIDELINES.md) | Generic CRUD template method, mapping, filtering, transactions |
+
+When adding a new norm file, document it in [Norm files](#norm-files) and extend [Which norm file applies?](#which-norm-file-applies).

--- a/spdd/norms/USE_CASE_IMPLEMENTATION.md
+++ b/spdd/norms/USE_CASE_IMPLEMENTATION.md
@@ -1,0 +1,187 @@
+# Guidelines: Implementing a Use Case
+
+This document describes how use cases are structured: REST surface, application orchestration, factories, domain commands, presenters, and outbound ports.
+
+## Architecture at a glance
+
+The flow is:
+
+**HTTP** → **Controller** (`*UseCaseController`) → **Use cases service** (`*UseCasesService`) → **Factory** (`*Factory`) → **Use case** (implements `UseCase`) → **Outbound ports** (interfaces) → **Adapters** (`*OutboundPortImpl`) → **Core / infrastructure** (CRUD services, clients, etc.).
+
+- The **use case** stays free of Spring and HTTP: it receives a **command** (domain input) and talks to the outside world only through **ports**.
+- The **presenter** is the use case’s output boundary: it receives domain results (e.g. `presentX(...)`).
+- The **factory** is the composition root for a single use case: it wires concrete port implementations and returns a `UseCase` instance.
+- The **use cases service** adapts REST DTOs to commands, runs the use case, and maps domain results back to API resources.
+
+### Hard boundaries (use case package)
+
+- **REST resources (`*CommandRes`, `*ResultRes`, and any `*Res` under `rest.v<*>.resources`) MUST NOT** be referenced inside the use case package (`...services.usecases.*`). They belong to the HTTP adapter; only the **use cases service** (and controller) may use them.
+- **Commands** passed into the use case MUST carry **domain data only**: JPA **entities**, value types, or **small immutable records** you declare for denormalized input—never API DTOs.
+- **Presenters** MUST accept **domain results** (entities, domain records, or primitives)—not `*Res` types.
+- **Outbound port implementations** (`*OutboundPortImpl`) MUST be **plain Java classes** (no `@Component`, `@Service`, or other Spring stereotypes). The **factory** is the only `@Component` in that slice: it constructs port impls with `new` and passes **Spring-injected collaborators** (core services, mappers, clients, `TransactionalOutboundPort`) into their constructors. Port interfaces stay free of framework types.
+
+```mermaid
+flowchart LR
+  subgraph rest [REST]
+    C[UseCaseController]
+    DTO[CommandRes / ResultRes]
+  end
+  subgraph app [Application]
+    UCS[*UseCasesService]
+    F[*Factory]
+    UC[Use case class]
+  end
+  subgraph boundaries [Boundaries]
+    Cmd[Command record]
+    Pres[Presenter interface]
+    P[Outbound ports]
+  end
+  C --> UCS
+  DTO --> UCS
+  UCS --> Cmd
+  UCS --> F
+  F --> UC
+  UC --> Cmd
+  UC --> Pres
+  UC --> P
+```
+
+
+
+---
+
+## 1. Shared building blocks (`utils.usecases`)
+
+
+| Artifact                    | Role                                                                                                                                                                                                                  |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UseCase`                   | Single method: `void execute()`. Every use case class implements this interface.                                                                                                                                      |
+| `TransactionalOutboundPort` | Wraps work in a transaction (`doInTransaction`, `doInTransactionWithResults`). Injected into factories; implemented by `DefaultTransactionalOutboundPortImpl` (Spring `TransactionTemplate`, serializable isolation). |
+
+
+Use the transactional port inside the use case when the operation must be atomic (typical for persistence + side effects that belong in the same transaction).
+
+---
+
+## 2. REST API: controller and resources
+
+### Controller
+
+- **Package:** `...controllers`
+- **Class name:** `*UseCaseController` (e.g. `DataProductUseCaseController`).
+- **Annotations:** `@RestController`, `@RequestMapping`, `produces = MediaType.APPLICATION_JSON_VALUE`.
+- **Responsibility:** Map HTTP to the corresponding `*UseCasesService` method only. No business rules.
+- **OpenAPI:** `@Tag`, `@Operation`, `@ApiResponses`, `@Parameter`; use `@Schema(implementation = ...)` on responses where applicable. Use `@Hidden` for endpoints that should not appear in public API docs.
+
+### Resources (DTOs)
+
+- **Package:** `rest.v2.resources.<aggregate>.usecases.<verb>` (e.g. `...dataproduct.usecases.init`).
+- **Naming:**
+  - Request body: `*CommandRes` (e.g. `DataProductInitCommandRes`).
+  - Response body: `*ResultRes` when returning payload (e.g. `DataProductInitResultRes`).
+- **Content:** JavaBeans with getters/setters (and empty constructor for Jackson), fields documented with `@Schema` where useful.
+- **Mapping:** Use existing mappers under `rest.v2.resources` (e.g. `DataProductMapper`, `DataProductRepoMapper`) to convert between `*Res` and **domain entities** inside the use cases service—not inside the controller.
+
+---
+
+## 3. Use cases service (`*UseCasesService`)
+
+- **Package:** `...<aggregate>.services` (e.g. `dataproduct.services`).
+- **Annotation:** `@Service`.
+- **Responsibility:**
+  1. Convert `*CommandRes` → domain **command** (record) using mappers (`toEntity`, etc.). This is the **only** layer that bridges `*Res` ↔ entities for the use case.
+  2. Build a **presenter** implementation:
+    - Often a **private static inner class** `*ResultHolder` that implements the presenter interface and stores the last `present*` argument for later `getResult()`.
+    - For void outcomes, a **lambda** implementing the presenter is acceptable when there is nothing to return (e.g. delete).
+  3. Call `factory.build...(command, presenter).execute()`.
+  4. Map domain result to `*ResultRes` when needed.
+
+Keep this class as the single place that knows both REST mappers and use-case boundaries for that aggregate’s use cases.
+
+---
+
+## 4. Use case package layout
+
+For one behavioral slice (e.g. “initialize data product”), colocate under `...services.usecases.<name>`:
+
+
+| File                     | Purpose                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `<Name>.java`            | Use case class: `class <Name> implements UseCase`, **package-private**.              |
+| `<Name>Command.java`     | Input: **Java `record`** (or equivalent) holding **entities** and/or **declared domain records**—never `*Res` types. |
+| `<Name>Presenter.java`   | Output boundary: methods use **domain types** only (e.g. `presentRegistered(Blueprint entity)`), not REST DTOs. |
+| `<Name>Factory.java`     | **`@Component`** (sole Spring bean here); method `UseCase build...(Command, Presenter)`. Instantiates port impls with `new`. |
+| `*OutboundPort.java`     | Port interfaces (persistence, validation, notification, …). Domain-level method signatures. |
+| `*OutboundPortImpl.java` | **Plain classes** (not Spring beans): implement ports; receive collaborators via constructor only. |
+
+
+Optional: split ports by concern (`...PersistenceOutboundPort`, `...NotificationOutboundPort`, `...ValidationOutboundPort`, etc.).
+
+---
+
+## 5. Use case class
+
+- Implements `UseCase` and implements `execute()`.
+- **Constructor** receives: command, presenter, outbound ports, and `TransactionalOutboundPort` when transactions are required.
+- **Visibility:** package-private (`class Foo implements UseCase`) so only the factory in the same package constructs it.
+- **Logic:** Validate command; orchestrate ports; call presenter methods when the business outcome is ready. Throw domain/API exceptions (`BadRequestException`, etc.) for invalid state. Must contain ONLY business logic.
+- **No** `@Autowired` on the use case class itself.
+- **No** spring annotations on the use case class itself.
+
+---
+
+## 6. Command and presenter
+
+- **Command:** Immutable **record** with **domain types only** (entities, UUIDs, enums, or small records you define in the use case package for structured input). **Never** use `*Res` / REST resources in the command.
+- **Presenter:** Interface named `<Action>Presenter` with one or more `present...` methods using **domain types** for arguments. The use case calls these to push results outward; the use cases service maps domain results to `*ResultRes` for HTTP.
+
+---
+
+## 7. Factories (`*Factory`)
+
+- `**@Component`** in the same package as the use case (typically the **only** `@Component` in that package).
+- **Inject** Spring beans needed to **construct** port implementations: core services (`*Service`, `*CrudService`), `TransactionalOutboundPort`, clients, **MapStruct mappers** between entities and `*Res` when ports need them, etc.
+- **Method signature:** `public UseCase build<Name>(<Name>Command command, <Name>Presenter presenter)`.
+- **Inside:** `new <Name>OutboundPortImpl(...)` for each port—**never** register port impls as Spring beans. Pass `new <Name>(command, presenter, ...ports, transactionalOutboundPort)`.
+
+The factory is the only place that chooses concrete port implementations for that use case.
+
+---
+
+## 8. Outbound ports and adapters
+
+- **Interface:** `<UseCase><Concern>OutboundPort` (e.g. `DataProductInitializerPersistenceOutboundPort`). Methods express what the use case needs in **domain terms** (`save(Blueprint)`, `validate(Blueprint)`, `emit...`)—not SQL, REST, or `*Res` types.
+- **Implementation:** `<UseCase><Concern>OutboundPortImpl` is a **plain Java class** (no `@Component` / `@Service`). It receives **constructor-injected** collaborators supplied by the factory (core `*Service`, mappers, clients). It may call:
+  - **Core layer** services (e.g. `DataProductsService`, `DescriptorVariableCrudService`), or
+  - **Clients** (e.g. `NotificationClient`), with entity ↔ `*Res` mapping **inside the impl** when the core API still uses resources.
+- **Visibility:** Port interfaces and their impls are often **package-private** so the boundary stays inside the use case package.
+- **Transactional port:** Shared across use cases; do not reimplement transaction handling inside each use case—delegate to `TransactionalOutboundPort`.
+- **No Spring on port impls:** If a concern needs to be testable in isolation, use plain `new` in unit tests or test the factory with mocked collaborators—not `@MockBean` on the impl type as a bean.
+
+---
+
+## 9. Core services vs use case layer
+
+- `**...services.core.*`** (and similar): CRUD, queries, reusable domain operations. Use cases **do not** call these directly from the use case class; they go through outbound ports whose impls delegate to core services.
+- `**utils.usecases`:** Cross-cutting use-case infrastructure (`UseCase`, `TransactionalOutboundPort`).
+
+---
+
+## 10. Testing
+
+- Add or extend **integration tests** for use case controllers (e.g. `*UseCaseControllerIT` under `src/test/java/...rest.v2.controllers`) to verify the full stack for the new endpoint.
+- Unit-test complex port adapters or use case logic where it pays off (existing project uses tests such as `*OutboundPortTest` in some areas).
+
+---
+
+## 11. Checklist for a new use case
+
+1. Define **command** record (domain only) and **presenter** interface (domain arguments only) in `...services.usecases.<name>`.
+2. Define **outbound port** interfaces and **plain `*OutboundPortImpl` classes** (no Spring annotations). Implement validation/persistence/etc. with collaborators passed from the factory.
+3. Add **`@Component` factory** only: construct port impls with `new`, inject `TransactionalOutboundPort` and core services/mappers.
+4. Add `***UseCasesService`** methods (or extend an existing one): map `*CommandRes` → entity/command, run factory + `execute()`, map domain result from presenter to `*ResultRes`.
+5. Add `**CommandRes` / `ResultRes**` under `rest.v2.resources...usecases...` with OpenAPI `@Schema` as needed.
+6. Add `**@RestController**` endpoint calling the use cases service; document with OpenAPI.
+7. Add **integration test** for the new route.
+
+Following these steps keeps new behavior consistent with the existing hexagonal-style layout: **ports/adapters** for infrastructure, **use case** for orchestration, **REST** as a thin adapter on top of the use cases service.

--- a/spdd/prompt/BDMD-5357-202607221134-[Feat]-service-quality-check-name-code-conflict.md
+++ b/spdd/prompt/BDMD-5357-202607221134-[Feat]-service-quality-check-name-code-conflict.md
@@ -1,0 +1,323 @@
+# Quality Check Name/Code Conflict Guard on Upload
+
+## Requirements
+Detect and warn when a descriptor-derived Quality Check would collide with an existing Blindata check in the same Quality Suite that shares the same display `name` but has a different `code`—typically after renaming `quality.name` without updating `customProperties.displayName` or using a stable `quality.id`—so the observer validator can fail policy evaluation with a clear, remediable message before Blindata’s opaque name-conflict create failure.
+
+## Entities
+```mermaid
+classDiagram
+direction TB
+
+class QualityUpload {
+  -QualityUploadBlindataOutboundPort blindataOutboundPort
+  -QualityUploadOdmOutboundPort odmOutboundPort
+  +execute()
+  -detectNameCodeConflicts(BDQualitySuiteRes, List~QualityCheck~)
+}
+
+class QualityUploadBlindataOutboundPort {
+  <<interface>>
+  +uploadQuality(BDQualitySuiteRes, List~QualityCheck~) BDQualityUploadResultsRes
+  +findQualitySuiteByCode(String) Optional~BDQualitySuiteRes~
+  +findQualityChecks(QualityCheckSearchOptions) List~BDQualityCheckRes~
+  +findIssueCampaign(String) Optional~BDIssueCampaignRes~
+  +createIssueCampaign(BDIssueCampaignRes) BDIssueCampaignRes
+  +findUser(String) Optional~BDShortUserRes~
+}
+
+class QualityUploadBlindataOutboundPortImpl {
+  -BdQualityClient bdQualityClient
+  +findQualitySuiteByCode(String) Optional~BDQualitySuiteRes~
+  +findQualityChecks(QualityCheckSearchOptions) List~BDQualityCheckRes~
+}
+
+class QualityUploadBlindataOutboundPortDryRunImpl {
+  -QualityUploadBlindataOutboundPort outboundPort
+  +uploadQuality(...) BDQualityUploadResultsRes
+  +findQualitySuiteByCode(String) Optional~BDQualitySuiteRes~
+  +findQualityChecks(QualityCheckSearchOptions) List~BDQualityCheckRes~
+}
+
+class BdQualityClient {
+  <<interface>>
+  +uploadQuality(BDQualityUploadRes) BDQualityUploadResultsRes
+  +getQualitySuites(Pageable, QualitySuitesSearchOptions) Page~BDQualitySuiteRes~
+  +getQualityChecks(Pageable, QualityCheckSearchOptions) Page~BDQualityCheckRes~
+}
+
+class QualityCheck {
+  +String code
+  +String name
+  +boolean isReference
+}
+
+class BDQualitySuiteRes {
+  +String uuid
+  +String code
+  +String name
+}
+
+class BDQualityCheckRes {
+  +String uuid
+  +String code
+  +String name
+  +BDQualitySuiteRes qualitySuite
+}
+
+class QualitySuitesSearchOptions {
+  +String search
+}
+
+class QualityCheckSearchOptions {
+  +String search
+  +String code
+  +List~String~ suiteUuid
+}
+
+class NameCodeConflict {
+  <<domain record / pair>>
+  +String incomingCode
+  +String incomingName
+  +String existingCode
+  +String existingName
+}
+
+QualityUpload --> QualityUploadBlindataOutboundPort : uses
+QualityUploadBlindataOutboundPortImpl ..|> QualityUploadBlindataOutboundPort
+QualityUploadBlindataOutboundPortDryRunImpl ..|> QualityUploadBlindataOutboundPort
+QualityUploadBlindataOutboundPortDryRunImpl --> QualityUploadBlindataOutboundPort : delegates reads
+QualityUploadBlindataOutboundPortImpl --> BdQualityClient : calls
+QualityUpload --> QualityCheck : validates
+QualityUpload --> BDQualitySuiteRes : builds / resolves
+QualityUpload --> NameCodeConflict : detects
+BdQualityClient --> QualitySuitesSearchOptions : filters
+BdQualityClient --> QualityCheckSearchOptions : filters
+BdQualityClient --> BDQualityCheckRes : returns
+```
+
+## Approach
+1. Pre-upload conflict guard (observer-side):
+   - After suite codes are prefixed onto checks (`addQualitySuiteCodeToQualityChecksCode`), resolve the Blindata Quality Suite by suite `code`.
+   - If the suite is absent, skip the guard (first upload cannot collide).
+   - If present, load existing checks for that suite (prefer suite-scoped search once, not per-check round-trips).
+   - For each incoming non-reference check, detect an existing Blindata check with exact equal `name` and different `code`.
+   - Collect **all** conflicts; emit one `getUseCaseLogger().warn(...)` per conflict (validator-consumable), identifying both checks and suggesting update of `customProperties.displayName` **or** use of a stable `quality.id`.
+   - Do **not** throw `UseCaseExecutionException` for this conflict; do **not** change Blindata upsert identity or descriptor code/name mapping.
+
+2. Technical implementation:
+   - Extend `BdQualityClient` + `BdClientImpl` with paginated read APIs mirroring Blindata `GET /api/v1/data-quality/suites` and `GET /api/v1/data-quality/checks`, reusing existing `QualitySuitesSearchOptions` / `QualityCheckSearchOptions`.
+   - Expose suite/check lookup on `QualityUploadBlindataOutboundPort`; implement in `QualityUploadBlindataOutboundPortImpl`.
+   - In `QualityUploadBlindataOutboundPortDryRunImpl`, **delegate** lookup methods to the wrapped live port (same pattern as `findIssueCampaign` / `findUser`); keep `uploadQuality` and `createIssueCampaign` no-op/stubbed.
+   - Post-filter Blindata LIKE/`search` results with exact `name` equality to avoid false positives.
+   - Prefer resolve suite once, then fetch checks filtered by `suiteUuid` (and optional search), then exact-match in memory.
+
+3. Business logic:
+   - Upsert identity remains `code` within suite; display `name` remains unique per suite on Blindata.
+   - Conflict = same suite + same name + different code.
+   - Matching code+name (update path) and new names (create path) must not warn.
+   - References already stripped before guard; run guard only on final upload candidates.
+   - Warning message must include incoming code/name, existing Blindata code/name, and dual remediation guidance.
+   - Live upload continues after warn (residual Blindata conflict if validator bypassed is accepted); validator dry-run is the enforcement path.
+
+## Structure
+
+### Inheritance Relationships
+1. `UseCase` interface defines `execute()` — implemented by package-private `QualityUpload`
+2. `QualityUploadBlindataOutboundPort` interface defines Blindata side effects/reads for quality upload
+3. `QualityUploadBlindataOutboundPortImpl` implements live Blindata adapter (plain Java, factory-constructed)
+4. `QualityUploadBlindataOutboundPortDryRunImpl` implements dry-run decorator: stubs writes, delegates reads
+5. `BdQualityClient` interface extended with suite/check page reads; `BdClientImpl` implements them
+
+### Dependencies
+1. `QualityUpload` calls `QualityUploadBlindataOutboundPort` for suite/check lookup and upload
+2. `QualityUploadBlindataOutboundPortImpl` depends on `BdQualityClient`, `BdIssueCampaignClient`, `BdUserClient`, `QualityCheckMapper`, `BdIssueManagementConfig`
+3. `QualityUploadFactory` (`@Component`) wires live and dry-run ports with `new`
+4. `BlindataValidatorService` runs `qualityUploadFactory.getUseCaseDryRun(...).execute()` under `ValidatorUseCaseLogger`
+
+### Layered Architecture
+1. Event / Validator Layer: notification events and `BlindataValidatorService` dry-run orchestration
+2. Use Case Layer: `QualityUpload` orchestration including name/code conflict guard
+3. Outbound Port Layer: `QualityUploadBlindataOutboundPort` (+ dry-run decorator)
+4. Client Layer: `BdQualityClient` / `BdClientImpl` HTTP to Blindata quality APIs
+5. Exception / Logging Layer: `getUseCaseLogger().warn` → `ValidatorUseCaseLogger` → policy `evaluationResult=false` (no new GlobalExceptionHandler; observer is event-driven)
+
+## Operations
+
+### Extend Client - BdQualityClient / BdClientImpl
+1. Responsibility: Enable read of Blindata quality suites and checks for pre-upload conflict detection
+2. Methods:
+   - `getQualitySuites(Pageable pageable, QualitySuitesSearchOptions filters): Page<BDQualitySuiteRes>`
+     - Logic: `GET {blindataUrl}/api/v1/data-quality/suites` via `restUtils.getPage`, map ClientException → BlindataClientException (same pattern as campaigns/policies)
+   - `getQualityChecks(Pageable pageable, QualityCheckSearchOptions filters): Page<BDQualityCheckRes>`
+     - Logic: `GET {blindataUrl}/api/v1/data-quality/checks` via `restUtils.getPage`
+3. Constraints: Reuse existing search option DTOs; no new Blindata DTO shapes unless fields are missing for uuid/code/name
+
+### Update Outbound Port - QualityUploadBlindataOutboundPort (+ Impl + DryRun)
+1. Responsibility: Expose suite resolve and suite-scoped check listing to the use case
+2. Methods:
+   - `findQualitySuiteByCode(String suiteCode): Optional<BDQualitySuiteRes>`
+     - Logic: search suites (e.g. `search`/`filters` with suite code), then exact-match `code` equality; return first exact match or empty
+   - `findQualityChecks(QualityCheckSearchOptions options): List<BDQualityCheckRes>` (or Page → list content)
+     - Logic: call `BdQualityClient.getQualityChecks` with suiteUuid set; return content (paginate if needed until exhausted for the suite when conflict scanning)
+3. Dry-run:
+   - `findQualitySuiteByCode` / `findQualityChecks` **delegate** to wrapped live port
+   - `uploadQuality` remains empty-result stub; `createIssueCampaign` remains stub
+4. Annotations: none on port/impl (plain Java); factory remains sole `@Component` in slice
+
+### Update Use Case - QualityUpload
+1. Responsibility: After `addQualitySuiteCodeToQualityChecksCode`, run name/code conflict guard before `uploadQuality`
+2. Methods:
+   - `detectAndWarnNameCodeConflicts(BDQualitySuiteRes qualitySuite, List<QualityCheck> qualityChecks): void`
+     - Logic:
+       1. `Optional<BDQualitySuiteRes> existingSuite = blindataOutboundPort.findQualitySuiteByCode(qualitySuite.getCode())`
+       2. If empty → return (no-op)
+       3. Build `QualityCheckSearchOptions` with `suiteUuid = List.of(existingSuite.get().getUuid())`
+       4. Load Blindata checks for suite (handle pagination)
+       5. Index existing checks by exact `name` (or iterate); for each incoming check with text name+code:
+          - Find existing where `Objects.equals(existing.getName(), incoming.getName())` AND `!Objects.equals(existing.getCode(), incoming.getCode())`
+          - On match → `getUseCaseLogger().warn` with both parties + remediation (displayName **or** stable `quality.id`); assign next `[#NN]` warning tag consistent with existing series (after [#63])
+       6. Collect/report **all** conflicts (no fail-fast)
+     - Exception Handling: do not throw for conflict; BlindataClientException handling remains via existing `withErrorHandling`
+3. Call site: invoke after suite code prefixing, before `blindataOutboundPort.uploadQuality(...)`
+4. Constraints: do not alter mapping of code/name; do not auto-heal by rewriting codes
+
+### Extend Unit Tests - QualityUploadTest
+1. Responsibility: Cover guard unit behavior with mocked outbound port
+2. Cases:
+   - Suite absent → no warn, upload still invoked
+   - Same name different code → warn once (or N times for N conflicts), upload still invoked
+   - Same name same code → no warn
+   - Multiple conflicts → all warned
+3. Mock `findQualitySuiteByCode` / `findQualityChecks` as needed; existing upload tests must stub new methods (default empty) so they keep passing
+
+### Create IT Tests with Gherkin - QualityUpload Name/Code Conflict (and/or Validator dry-run IT)
+1. Responsibility: Validate acceptance criteria end-to-end against Spring IT harness (`ObserverBlindataAppIT` pattern), with Gherkin documented on each `@Test` (same style as `DataProductDeletionIT`)
+2. Embed the following Feature in IT class Javadoc / method Javadoc and implement scenarios as tests (mock `BdQualityClient` reads + dry-run / validator path as appropriate):
+
+```gherkin
+Feature: Quality check name/code conflict detection on QUALITY_UPLOAD
+  In order to avoid opaque Blindata create failures when renaming quality.name without aligning display identity
+  As the Blindata observer
+  I want to detect same-name / different-code collisions within a Quality Suite and emit clear warnings
+  So that the observer validator fails policy evaluation with remediable messages before publish
+
+  Background:
+    Given a data product in domain "sales" with name "orders"
+    And the Quality Suite code is "sales - orders"
+    And QUALITY_UPLOAD extracts quality checks from descriptor ports
+    And quality check codes are prefixed with the suite code before upload
+    And Blindata upsert identity for quality checks is by code within the suite
+    And Blindata enforces unique quality check name within the suite
+
+  Scenario: AC1-AC3 — renamed technical name with unchanged displayName is detected and warned
+    Given Blindata already has Quality Suite "sales - orders"
+    And the suite contains a Quality Check with code "sales - orders - old_rule" and name "Customer Completeness"
+    And the descriptor quality object has name "new_rule" without quality.id
+    And customProperties.displayName is "Customer Completeness"
+    When QUALITY_UPLOAD runs (live or dry-run)
+    Then the observer resolves the suite on Blindata by code "sales - orders"
+    And it detects a name/code conflict between incoming code "sales - orders - new_rule" / name "Customer Completeness"
+      and existing code "sales - orders - old_rule" / name "Customer Completeness"
+    And it emits a use-case warn identifying both checks
+    And the warn suggests updating customProperties.displayName or using a stable quality.id
+    And the warn is collected by ValidatorUseCaseLogger when running under the validator
+
+  Scenario: AC2 — verify no Blindata check exists with same name and different code
+    Given Blindata already has Quality Suite "sales - orders"
+    And the suite contains Quality Check code "sales - orders - rule_a" name "Rule A"
+    And the incoming check has code "sales - orders - rule_a" and name "Rule A"
+    When QUALITY_UPLOAD runs the conflict guard
+    Then no name/code conflict warning is emitted for that check
+
+  Scenario: AC3 — collect all conflicts in one upload
+    Given Blindata already has Quality Suite "sales - orders"
+    And the suite contains checks:
+      | code                         | name     |
+      | sales - orders - old_one     | Name One |
+      | sales - orders - old_two     | Name Two |
+    And the descriptor produces incoming checks:
+      | code                         | name     |
+      | sales - orders - new_one     | Name One |
+      | sales - orders - new_two     | Name Two |
+    When QUALITY_UPLOAD runs the conflict guard
+    Then two distinct use-case warnings are emitted
+    And each warning identifies its conflicting pair
+    And under the validator both warnings appear in rawError
+
+  Scenario: AC4 — happy path upload/update by code continues without conflict warn
+    Given Blindata already has Quality Suite "sales - orders"
+    And the suite contains Quality Check code "sales - orders - stable" name "Stable Name"
+    And the incoming check has code "sales - orders - stable" and name "Stable Name"
+    When QUALITY_UPLOAD completes
+    Then no name/code conflict warning is emitted
+    And uploadQuality is invoked with the prefixed checks (live path)
+    And dry-run stubs upload without error (validator path)
+
+  Scenario: AC4b — intentional rename of both technical name and display name creates new check identity without this conflict
+    Given Blindata already has Quality Suite "sales - orders"
+    And the suite contains Quality Check code "sales - orders - old_rule" name "Old Display"
+    And the descriptor quality object has name "new_rule"
+    And customProperties.displayName is "New Display"
+    When QUALITY_UPLOAD runs the conflict guard
+    Then no name/code conflict warning is emitted for that check
+    And Blindata would treat the incoming check as a different name (create-by-new-name path)
+
+  Scenario: AC5 — first upload / suite absent is a no-op for the guard
+    Given Blindata does not contain Quality Suite "sales - orders"
+    And the descriptor defines one or more quality checks
+    When QUALITY_UPLOAD runs the conflict guard
+    Then findQualitySuiteByCode returns empty
+    And no name/code conflict warning is emitted
+    And upload proceeds as today (live) or dry-run stub upload (validator)
+
+  Scenario: AC6 — observer validator dry-run surfaces conflict and fails policy evaluation
+    Given the Blindata validator policy evaluation runs QUALITY_UPLOAD in dry-run
+    And Blindata already has Quality Suite "sales - orders" with an existing same-name / different-code check
+    And the descriptor produces a conflicting incoming check
+    When BlindataValidatorService validates the data product
+    Then QualityUploadBlindataOutboundPortDryRunImpl still performs suite/check read lookups against Blindata
+    And uploadQuality is not persisted (dry-run stub)
+    And ValidatorUseCaseLogger collects the conflict warning(s)
+    And evaluationResult is false
+    And rawError lists every collected warning message
+
+  Scenario: Fuzzy Blindata search must not false-positive without exact name match
+    Given Blindata suite-scoped search returns a check whose name only partially matches the incoming name
+    When the conflict guard post-filters by exact name equality
+    Then no conflict warning is emitted for that partial match
+```
+
+3. Implementation notes for ITs:
+   - Prefer extending existing IT base (`ObserverBlindataAppIT`) and mocking `BdQualityClient` for suite/check pages
+   - Trace each `@Test` to AC# via Feature/Scenario Javadoc comment
+   - Assert warn delivery through validator result when testing AC6; assert port interactions for AC1–AC5 unit/IT hybrids
+   - Do not require real Blindata; mock page responses with uuid/code/name
+
+### Keep Mapping Unchanged
+1. Responsibility: No changes to `DataStoreApiStandardDefinitionVisitorImpl` quality code/name/`displayName` mapping for this ticket
+2. Constraints: Detection-only fix; do not derive Blindata name solely from `quality.name` or require `id` globally
+
+## Norms
+1. Annotation standards: Follow observer use-case slice rules from `spdd/norms/USE_CASE_IMPLEMENTATION.md` adapted to this repo — `@Component` only on `QualityUploadFactory`; no Spring stereotypes on `QualityUpload`, `*OutboundPortImpl`, or dry-run decorator. Client methods live on `BdQualityClient` / `BdClientImpl` without introducing a new controller (event/validator driven, not REST use-case controller).
+2. Dependency injection: Constructor injection into factory; port impls constructed with `new` inside factory (`spdd/norms/README.md` cross-cutting DI; `spdd/norms/USE_CASE_IMPLEMENTATION.md` §7–8).
+3. Exception handling:
+   - Conflict path uses `getUseCaseLogger().warn` only — do not throw `UseCaseExecutionException` for name/code conflicts (`spdd/analysis` product decision; aligns with existing quality validation warns [#46]–[#63]).
+   - Retain existing `withErrorHandling` for BlindataClientException / unexpected errors.
+   - No new GlobalExceptionHandler required for this feature (observer is not exposing a new REST command surface).
+4. Data validation: Exact name equality after Blindata search; suite-scoped comparison only; skip when suite missing; skip references (already removed).
+5. Logging: Use `UseCaseLogger` / `getUseCaseLogger()` with `[QualityUpload]` prefix and a new `[#NN]` tag; never log secrets; ensure validator dry-run captures warns via `ValidatorUseCaseLogger` (`spdd/norms/README.md` Logging + Testing).
+6. Documentation standards: Document IT scenarios with embedded Gherkin Feature/Scenario Javadoc (`DataProductDeletionIT` style); keep OpenAPI N/A for this change.
+7. Use-case boundaries (`spdd/norms/USE_CASE_IMPLEMENTATION.md`): Orchestration stays in `QualityUpload`; Blindata HTTP stays behind outbound port + `BdQualityClient`; dry-run decorator must not stub conflict-detection reads.
+8. CRUD template norms (`spdd/norms/GENERIC-CRUD-GUIDELINES.md`): **Not applicable** — no JPA Generic CRUD for this feature.
+
+## Safeguards
+1. Functional Constraints: Detection only; mapping of code/name/displayName unchanged; upsert remains by code; warn-not-throw for conflicts; collect all conflicts; suite-absent is no-op.
+2. Performance Constraints: Resolve suite once per upload; load checks suite-scoped (paginate as needed) rather than one Blindata round-trip per incoming check when avoidable.
+3. Security Constraints: Do not log credentials or Blindata auth headers; warning messages must not include sensitive tokens—only quality check codes/names and remediation text.
+4. Integration Constraints: Reuse Blindata public list APIs (`/api/v1/data-quality/suites`, `/api/v1/data-quality/checks`) and existing search option DTOs; dry-run must still call read APIs.
+5. Business Rule Constraints: Conflict iff same suite + exact same name + different code; remediations must mention both displayName update and stable `quality.id`.
+6. Exception Handling Constraints: Conflicts are warns for validator consumption; do not introduce hard-fail `UseCaseExecutionException` for this scenario; do not rely solely on SLF4J (would bypass validator).
+7. Technical Constraints: No Blindata-side upsert-by-name change; no silent auto-heal rewriting codes; exact name post-filter mandatory after LIKE/search.
+8. Data Constraints: Guard runs on final non-reference checks after suite-code prefixing; empty/missing names should not invent collisions.
+9. API Constraints: No new observer REST endpoints required; extend client/port contracts only as needed for reads.
+10. Test Constraints: Unit tests cover guard branches; IT tests embed Gherkin for AC1–AC6 and verify validator `evaluationResult=false` when warnings present.

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdClientImpl.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdClientImpl.java
@@ -18,8 +18,12 @@ import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.mark
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.physical.BDSystemRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.physical.BDSystemSearchOptions;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.product.*;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualityCheckSearchOptions;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualitySuitesSearchOptions;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -413,6 +417,40 @@ public class BdClientImpl implements BdDataProductClient, BdStewardshipClient, B
                     null,
                     qualityUpload,
                     BDQualityUploadResultsRes.class
+            );
+        } catch (ClientException e) {
+            throw new BlindataClientException(e.getCode(), e.getResponseBody());
+        } catch (ClientResourceMappingException e) {
+            throw new BlindataClientResourceMappingException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Page<BDQualitySuiteRes> getQualitySuites(Pageable pageable, QualitySuitesSearchOptions filters) {
+        try {
+            return restUtils.getPage(
+                    String.format("%s/api/v1/data-quality/suites", credentials.getBlindataUrl()),
+                    null,
+                    pageable,
+                    filters,
+                    BDQualitySuiteRes.class
+            );
+        } catch (ClientException e) {
+            throw new BlindataClientException(e.getCode(), e.getResponseBody());
+        } catch (ClientResourceMappingException e) {
+            throw new BlindataClientResourceMappingException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Page<BDQualityCheckRes> getQualityChecks(Pageable pageable, QualityCheckSearchOptions filters) {
+        try {
+            return restUtils.getPage(
+                    String.format("%s/api/v1/data-quality/checks", credentials.getBlindataUrl()),
+                    null,
+                    pageable,
+                    filters,
+                    BDQualityCheckRes.class
             );
         } catch (ClientException e) {
             throw new BlindataClientException(e.getCode(), e.getResponseBody());

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdQualityClient.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/client/blindata/BdQualityClient.java
@@ -1,8 +1,18 @@
 package org.opendatamesh.platform.up.metaservice.blindata.client.blindata;
 
-import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualityCheckSearchOptions;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualitySuitesSearchOptions;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface BdQualityClient {
     BDQualityUploadResultsRes uploadQuality(BDQualityUploadRes qualityUpload);
+
+    Page<BDQualitySuiteRes> getQualitySuites(Pageable pageable, QualitySuitesSearchOptions filters);
+
+    Page<BDQualityCheckRes> getQualityChecks(Pageable pageable, QualityCheckSearchOptions filters);
 }

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUpload.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUpload.java
@@ -7,9 +7,11 @@ import org.opendatamesh.platform.up.metaservice.blindata.client.blindata.excepti
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.collaboration.BDShortUserRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.issuemngt.BDIssueCampaignRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.issuemngt.BDIssueRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityStrategyRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualityCheckSearchOptions;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.internal.quality.QualityCheck;
 import org.opendatamesh.platform.up.metaservice.blindata.services.usecases.UseCase;
 import org.opendatamesh.platform.up.metaservice.blindata.services.usecases.exceptions.UseCaseExecutionException;
@@ -19,6 +21,7 @@ import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -63,6 +66,7 @@ class QualityUpload implements UseCase {
             updateIssuePoliciesOnQualityChecks(qualityChecks, issueCampaign, dataProductVersion);
 
             addQualitySuiteCodeToQualityChecksCode(qualitySuite, qualityChecks);
+            detectAndWarnNameCodeConflicts(qualitySuite, qualityChecks);
 
             BDQualityUploadResultsRes uploadResult = blindataOutboundPort.uploadQuality(qualitySuite, qualityChecks);
 
@@ -77,6 +81,41 @@ class QualityUpload implements UseCase {
         qualityChecks.forEach(qualityCheck -> qualityCheck.setCode(
                 String.format("%s - %s", qualitySuite.getCode(), qualityCheck.getCode())
         ));
+    }
+
+    private void detectAndWarnNameCodeConflicts(BDQualitySuiteRes qualitySuite, List<QualityCheck> qualityChecks) {
+        if (CollectionUtils.isEmpty(qualityChecks) || qualitySuite == null || !StringUtils.hasText(qualitySuite.getCode())) {
+            return;
+        }
+        Optional<BDQualitySuiteRes> existingSuite = blindataOutboundPort.findQualitySuiteByCode(qualitySuite.getCode());
+        if (existingSuite.isEmpty()) {
+            return;
+        }
+        QualityCheckSearchOptions searchOptions = new QualityCheckSearchOptions();
+        searchOptions.setSuiteUuid(Collections.singletonList(existingSuite.get().getUuid()));
+        List<BDQualityCheckRes> existingChecks = blindataOutboundPort.findQualityChecks(searchOptions);
+        if (CollectionUtils.isEmpty(existingChecks)) {
+            return;
+        }
+        for (QualityCheck incoming : qualityChecks) {
+            if (!StringUtils.hasText(incoming.getName()) || !StringUtils.hasText(incoming.getCode())) {
+                continue;
+            }
+            for (BDQualityCheckRes existing : existingChecks) {
+                if (Objects.equals(incoming.getName(), existing.getName())
+                        && !Objects.equals(incoming.getCode(), existing.getCode())) {
+                    getUseCaseLogger().warn(String.format(
+                            "[#121] %s Quality Check name/code conflict: incoming code='%s' name='%s' conflicts with existing Blindata code='%s' name='%s' in the same suite. " +
+                                    "Update customProperties.displayName (or the mapped display name) to match the renamed quality, or use a stable quality.id so the code no longer tracks quality.name.",
+                            USE_CASE_PREFIX,
+                            incoming.getCode(),
+                            incoming.getName(),
+                            existing.getCode(),
+                            existing.getName()
+                    ));
+                }
+            }
+        }
     }
 
     private void updateIssuePoliciesOnQualityChecks(List<QualityCheck> qualityChecks, BDIssueCampaignRes issueCampaign, DataProductVersion dataProductVersion) {

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadBlindataOutboundPort.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadBlindataOutboundPort.java
@@ -2,8 +2,10 @@ package org.opendatamesh.platform.up.metaservice.blindata.services.usecases.qual
 
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.collaboration.BDShortUserRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.issuemngt.BDIssueCampaignRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualityCheckSearchOptions;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.internal.quality.QualityCheck;
 
 import java.util.List;
@@ -12,6 +14,10 @@ import java.util.Optional;
 interface QualityUploadBlindataOutboundPort {
 
     BDQualityUploadResultsRes uploadQuality(BDQualitySuiteRes qualitySuite, List<QualityCheck> qualityChecks);
+
+    Optional<BDQualitySuiteRes> findQualitySuiteByCode(String suiteCode);
+
+    List<BDQualityCheckRes> findQualityChecks(QualityCheckSearchOptions options);
 
     Optional<BDIssueCampaignRes> findIssueCampaign(String campaignName);
 

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadBlindataOutboundPortDryRunImpl.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadBlindataOutboundPortDryRunImpl.java
@@ -2,8 +2,10 @@ package org.opendatamesh.platform.up.metaservice.blindata.services.usecases.qual
 
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.collaboration.BDShortUserRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.issuemngt.BDIssueCampaignRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualityCheckSearchOptions;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.internal.quality.QualityCheck;
 
 import java.util.List;
@@ -20,6 +22,16 @@ class QualityUploadBlindataOutboundPortDryRunImpl implements QualityUploadBlinda
     @Override
     public BDQualityUploadResultsRes uploadQuality(BDQualitySuiteRes qualitySuite, List<QualityCheck> qualityChecks) {
         return new BDQualityUploadResultsRes();
+    }
+
+    @Override
+    public Optional<BDQualitySuiteRes> findQualitySuiteByCode(String suiteCode) {
+        return outboundPort.findQualitySuiteByCode(suiteCode);
+    }
+
+    @Override
+    public List<BDQualityCheckRes> findQualityChecks(QualityCheckSearchOptions options) {
+        return outboundPort.findQualityChecks(options);
     }
 
     @Override

--- a/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadBlindataOutboundPortImpl.java
+++ b/src/main/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadBlindataOutboundPortImpl.java
@@ -9,12 +9,18 @@ import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.issu
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.issuemngt.BDIssuePolicyRes;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.*;
 import org.opendatamesh.platform.up.metaservice.blindata.resources.internal.quality.QualityCheck;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 class QualityUploadBlindataOutboundPortImpl implements QualityUploadBlindataOutboundPort {
+
+    private static final int PAGE_SIZE = 100;
 
     private final BdQualityClient bdQualityClient;
     private final BdIssueCampaignClient bdIssueClient;
@@ -47,6 +53,32 @@ class QualityUploadBlindataOutboundPortImpl implements QualityUploadBlindataOutb
         return bdQualityClient.uploadQuality(
                 new BDQualityUploadRes(qualitySuite, bdQualityChecks, issuePolicies)
         );
+    }
+
+    @Override
+    public Optional<BDQualitySuiteRes> findQualitySuiteByCode(String suiteCode) {
+        if (!StringUtils.hasText(suiteCode)) {
+            return Optional.empty();
+        }
+        QualitySuitesSearchOptions searchOptions = new QualitySuitesSearchOptions();
+        searchOptions.setSearch(suiteCode);
+        Page<BDQualitySuiteRes> page = bdQualityClient.getQualitySuites(Pageable.ofSize(PAGE_SIZE), searchOptions);
+        return page.getContent().stream()
+                .filter(suite -> Objects.equals(suiteCode, suite.getCode()))
+                .findFirst();
+    }
+
+    @Override
+    public List<BDQualityCheckRes> findQualityChecks(QualityCheckSearchOptions options) {
+        List<BDQualityCheckRes> allChecks = new ArrayList<>();
+        int pageNumber = 0;
+        Page<BDQualityCheckRes> page;
+        do {
+            page = bdQualityClient.getQualityChecks(PageRequest.of(pageNumber, PAGE_SIZE), options);
+            allChecks.addAll(page.getContent());
+            pageNumber++;
+        } while (page.hasNext());
+        return allChecks;
     }
 
     @Override

--- a/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadNameCodeConflictIT.java
+++ b/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadNameCodeConflictIT.java
@@ -1,0 +1,157 @@
+package org.opendatamesh.platform.up.metaservice.blindata.services.usecases.quality_upload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.io.Resources;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opendatamesh.platform.up.metaservice.blindata.ObserverBlindataAppIT;
+import org.opendatamesh.platform.up.metaservice.blindata.client.blindata.BdIssueCampaignClient;
+import org.opendatamesh.platform.up.metaservice.blindata.client.blindata.BdQualityClient;
+import org.opendatamesh.platform.up.metaservice.blindata.client.blindata.BdUserClient;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.validator.resources.OdmValidatorPolicyEvaluationRequestRes;
+import org.opendatamesh.platform.up.metaservice.blindata.validator.resources.OdmValidatorPolicyEvaluationResultRes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Feature: Quality check name/code conflict detection on QUALITY_UPLOAD
+ * In order to avoid opaque Blindata create failures when renaming quality.name without aligning display identity
+ * As the Blindata observer
+ * I want to detect same-name / different-code collisions within a Quality Suite and emit clear warnings
+ * So that the observer validator fails policy evaluation with remediable messages before publish
+ */
+public class QualityUploadNameCodeConflictIT extends ObserverBlindataAppIT {
+
+    @Autowired
+    private BdQualityClient bdQualityClient;
+    @Autowired
+    private BdIssueCampaignClient bdIssueCampaignClient;
+    @Autowired
+    private BdUserClient bdUserClient;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void resetMocks() {
+        Mockito.reset(bdQualityClient, bdIssueCampaignClient, bdUserClient);
+        when(bdIssueCampaignClient.getIssueCampaign(any())).thenReturn(java.util.Optional.empty());
+        when(bdIssueCampaignClient.createCampaign(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(bdUserClient.getBlindataUser(any())).thenReturn(java.util.Optional.empty());
+        when(bdQualityClient.uploadQuality(any())).thenReturn(new BDQualityUploadResultsRes());
+    }
+
+    /**
+     * Scenario: AC6 — observer validator dry-run surfaces conflict and fails policy evaluation
+     * Given the Blindata validator policy evaluation runs QUALITY_UPLOAD in dry-run
+     * And Blindata already has Quality Suite "testDomain - test" with an existing same-name / different-code check
+     * And the descriptor produces a conflicting incoming check
+     * When BlindataValidatorService validates the data product
+     * Then QualityUploadBlindataOutboundPortDryRunImpl still performs suite/check read lookups against Blindata
+     * And uploadQuality is not persisted (dry-run stub)
+     * And ValidatorUseCaseLogger collects the conflict warning(s)
+     * And evaluationResult is false
+     * And rawError lists every collected warning message
+     */
+    @Test
+    public void testValidatorFailsWhenQualityNameCodeConflictDetected() throws IOException {
+        BDQualitySuiteRes existingSuite = new BDQualitySuiteRes();
+        existingSuite.setUuid("suite-uuid");
+        existingSuite.setCode("testDomain - test");
+        existingSuite.setName("testDomain - test");
+
+        BDQualityCheckRes existingCheck = new BDQualityCheckRes();
+        existingCheck.setCode("testDomain - test - Macrozona ExpectColumnValuesToBeInSet OLD");
+        existingCheck.setName("Macrozona ExpectColumnValuesToBeInSet");
+
+        when(bdQualityClient.getQualitySuites(any(Pageable.class), any()))
+                .thenReturn(new PageImpl<>(Collections.singletonList(existingSuite)));
+        when(bdQualityClient.getQualityChecks(any(Pageable.class), any()))
+                .thenReturn(new PageImpl<>(Collections.singletonList(existingCheck)));
+
+        OdmValidatorPolicyEvaluationRequestRes request = buildValidatorRequestFromQualityUploadFixture();
+
+        ResponseEntity<OdmValidatorPolicyEvaluationResultRes> response = rest.postForEntity(
+                "http://localhost:" + port + "/api/v1/up/validator/evaluate-policy",
+                request,
+                OdmValidatorPolicyEvaluationResultRes.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getEvaluationResult()).isFalse();
+        assertThat(response.getBody().getOutputObject().getRawError().toString())
+                .contains("[#121]")
+                .contains("Macrozona ExpectColumnValuesToBeInSet")
+                .contains("customProperties.displayName")
+                .contains("quality.id");
+
+        verify(bdQualityClient, atLeastOnce()).getQualitySuites(any(Pageable.class), any());
+        verify(bdQualityClient, atLeastOnce()).getQualityChecks(any(Pageable.class), any());
+        verify(bdQualityClient, never()).uploadQuality(any());
+    }
+
+    /**
+     * Scenario: AC5 — first upload / suite absent is a no-op for the guard (validator path)
+     * Given Blindata does not contain Quality Suite "testDomain - test"
+     * When the Blindata validator evaluates the data product version with quality checks
+     * Then findQualitySuiteByCode returns empty
+     * And no name/code conflict warning [#121] is emitted for this reason
+     */
+    @Test
+    public void testValidatorDoesNotEmitConflictWhenSuiteAbsent() throws IOException {
+        when(bdQualityClient.getQualitySuites(any(Pageable.class), any()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+
+        OdmValidatorPolicyEvaluationRequestRes request = buildValidatorRequestFromQualityUploadFixture();
+
+        ResponseEntity<OdmValidatorPolicyEvaluationResultRes> response = rest.postForEntity(
+                "http://localhost:" + port + "/api/v1/up/validator/evaluate-policy",
+                request,
+                OdmValidatorPolicyEvaluationResultRes.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        if (Boolean.FALSE.equals(response.getBody().getEvaluationResult())) {
+            assertThat(response.getBody().getOutputObject().getRawError().toString()).doesNotContain("[#121]");
+        }
+        verify(bdQualityClient, atLeastOnce()).getQualitySuites(any(Pageable.class), any());
+        verify(bdQualityClient, never()).getQualityChecks(any(Pageable.class), any());
+        verify(bdQualityClient, never()).uploadQuality(any());
+    }
+
+    private OdmValidatorPolicyEvaluationRequestRes buildValidatorRequestFromQualityUploadFixture() throws IOException {
+        JsonNode dataProductVersion = objectMapper.readTree(
+                Resources.toByteArray(Objects.requireNonNull(
+                        getClass().getResource("/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/quality_upload_data_product_version.json")))
+        );
+        ObjectNode afterState = objectMapper.createObjectNode();
+        afterState.set("dataProductVersion", dataProductVersion);
+
+        ObjectNode objectToEvaluate = objectMapper.createObjectNode();
+        objectToEvaluate.set("afterState", afterState);
+        objectToEvaluate.putNull("currentState");
+
+        OdmValidatorPolicyEvaluationRequestRes request = new OdmValidatorPolicyEvaluationRequestRes();
+        request.setPolicyEvaluationId(5357L);
+        request.setObjectToEvaluate(objectToEvaluate);
+        return request;
+    }
+}

--- a/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadNameCodeConflictTest.java
+++ b/src/test/java/org/opendatamesh/platform/up/metaservice/blindata/services/usecases/quality_upload/QualityUploadNameCodeConflictTest.java
@@ -1,0 +1,362 @@
+package org.opendatamesh.platform.up.metaservice.blindata.services.usecases.quality_upload;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opendatamesh.dpds.model.DataProductVersion;
+import org.opendatamesh.dpds.model.info.Info;
+import org.opendatamesh.dpds.model.interfaces.InterfaceComponents;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityCheckRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualitySuiteRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.BDQualityUploadResultsRes;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.blindata.quality.QualityCheckSearchOptions;
+import org.opendatamesh.platform.up.metaservice.blindata.resources.internal.quality.QualityCheck;
+import org.opendatamesh.platform.up.metaservice.blindata.services.usecases.exceptions.UseCaseExecutionException;
+import org.opendatamesh.platform.up.metaservice.blindata.services.usecases.exceptions.UseCaseLogger;
+import org.opendatamesh.platform.up.metaservice.blindata.services.usecases.exceptions.UseCaseLoggerContext;
+import org.opendatamesh.platform.up.metaservice.blindata.services.usecases.exceptions.ValidatorUseCaseLogger;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Feature: Quality check name/code conflict detection on QUALITY_UPLOAD
+ * In order to avoid opaque Blindata create failures when renaming quality.name without aligning display identity
+ * As the Blindata observer
+ * I want to detect same-name / different-code collisions within a Quality Suite and emit clear warnings
+ * So that the observer validator fails policy evaluation with remediable messages before publish
+ * <p>
+ * Background:
+ * Given a data product in domain "sales" with name "orders"
+ * And the Quality Suite code is "sales - orders"
+ * And QUALITY_UPLOAD extracts quality checks from descriptor ports
+ * And quality check codes are prefixed with the suite code before upload
+ * And Blindata upsert identity for quality checks is by code within the suite
+ * And Blindata enforces unique quality check name within the suite
+ */
+@ExtendWith(MockitoExtension.class)
+public class QualityUploadNameCodeConflictTest {
+
+    private static final String SUITE_CODE = "sales - orders";
+    private static final String SUITE_UUID = "suite-uuid";
+
+    @Mock
+    private QualityUploadBlindataOutboundPort blindataOutboundPort;
+    @Mock
+    private QualityUploadOdmOutboundPort odmOutboundPort;
+    @Mock
+    private UseCaseLogger mockLogger;
+
+    private UseCaseLogger originalLogger;
+
+    @BeforeEach
+    void setUpLogger() {
+        originalLogger = UseCaseLoggerContext.getUseCaseLogger();
+        UseCaseLoggerContext.setUseCaseLogger(mockLogger);
+    }
+
+    @AfterEach
+    void restoreLogger() {
+        UseCaseLoggerContext.setUseCaseLogger(originalLogger);
+    }
+
+    /**
+     * Scenario: AC1-AC3 — renamed technical name with unchanged displayName is detected and warned
+     * Given Blindata already has Quality Suite "sales - orders"
+     * And the suite contains a Quality Check with code "sales - orders - old_rule" and name "Customer Completeness"
+     * And the descriptor quality object has name "new_rule" without quality.id
+     * And customProperties.displayName is "Customer Completeness"
+     * When QUALITY_UPLOAD runs
+     * Then the observer resolves the suite on Blindata by code "sales - orders"
+     * And it detects a name/code conflict between incoming code "sales - orders - new_rule" / name "Customer Completeness"
+     * and existing code "sales - orders - old_rule" / name "Customer Completeness"
+     * And it emits a use-case warn identifying both checks
+     * And the warn suggests updating customProperties.displayName or using a stable quality.id
+     */
+    @Test
+    void testConflictWarnsWhenSameNameDifferentCode() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("new_rule", "Customer Completeness")
+        ));
+        stubExistingSuite();
+        when(blindataOutboundPort.findQualityChecks(any())).thenReturn(Collections.singletonList(
+                existingCheck("sales - orders - old_rule", "Customer Completeness")
+        ));
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        ArgumentCaptor<String> warnCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger, atLeastOnce()).warn(warnCaptor.capture());
+        assertThat(warnCaptor.getAllValues()).anySatisfy(message -> {
+            assertThat(message).contains("[#121]");
+            assertThat(message).contains("sales - orders - new_rule");
+            assertThat(message).contains("sales - orders - old_rule");
+            assertThat(message).contains("Customer Completeness");
+            assertThat(message).contains("customProperties.displayName");
+            assertThat(message).contains("quality.id");
+        });
+        verify(blindataOutboundPort).findQualitySuiteByCode(SUITE_CODE);
+        verify(blindataOutboundPort).uploadQuality(any(), any());
+    }
+
+    /**
+     * Scenario: AC2 — verify no Blindata check exists with same name and different code
+     * Given Blindata already has Quality Suite "sales - orders"
+     * And the suite contains Quality Check code "sales - orders - rule_a" name "Rule A"
+     * And the incoming check has code "sales - orders - rule_a" and name "Rule A"
+     * When QUALITY_UPLOAD runs the conflict guard
+     * Then no name/code conflict warning is emitted for that check
+     */
+    @Test
+    void testNoWarnWhenSameNameSameCode() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("rule_a", "Rule A")
+        ));
+        stubExistingSuite();
+        when(blindataOutboundPort.findQualityChecks(any())).thenReturn(Collections.singletonList(
+                existingCheck("sales - orders - rule_a", "Rule A")
+        ));
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        verifyNoConflictWarn();
+        verify(blindataOutboundPort).uploadQuality(any(), any());
+    }
+
+    /**
+     * Scenario: AC3 — collect all conflicts in one upload
+     * Given Blindata already has Quality Suite "sales - orders" with two existing checks
+     * And the descriptor produces two conflicting incoming checks
+     * When QUALITY_UPLOAD runs the conflict guard
+     * Then two distinct use-case warnings are emitted
+     * And each warning identifies its conflicting pair
+     */
+    @Test
+    void testCollectsAllConflicts() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Arrays.asList(
+                qualityCheck("new_one", "Name One"),
+                qualityCheck("new_two", "Name Two")
+        ));
+        stubExistingSuite();
+        when(blindataOutboundPort.findQualityChecks(any())).thenReturn(Arrays.asList(
+                existingCheck("sales - orders - old_one", "Name One"),
+                existingCheck("sales - orders - old_two", "Name Two")
+        ));
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        ArgumentCaptor<String> warnCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger, atLeastOnce()).warn(warnCaptor.capture());
+        List<String> conflictWarns = warnCaptor.getAllValues().stream()
+                .filter(message -> message.contains("[#121]"))
+                .collect(Collectors.toList());
+        assertThat(conflictWarns).hasSize(2);
+        assertThat(conflictWarns.get(0)).contains("Name One").contains("old_one").contains("new_one");
+        assertThat(conflictWarns.get(1)).contains("Name Two").contains("old_two").contains("new_two");
+    }
+
+    /**
+     * Scenario: AC4 — happy path upload/update by code continues without conflict warn
+     * Given Blindata already has Quality Suite "sales - orders"
+     * And the suite contains Quality Check code "sales - orders - stable" name "Stable Name"
+     * And the incoming check has code "sales - orders - stable" and name "Stable Name"
+     * When QUALITY_UPLOAD completes
+     * Then no name/code conflict warning is emitted
+     * And uploadQuality is invoked with the prefixed checks
+     */
+    @Test
+    void testHappyPathSameIdentityUploadsWithoutConflictWarn() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("stable", "Stable Name")
+        ));
+        stubExistingSuite();
+        when(blindataOutboundPort.findQualityChecks(any())).thenReturn(Collections.singletonList(
+                existingCheck("sales - orders - stable", "Stable Name")
+        ));
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        verifyNoConflictWarn();
+        verify(blindataOutboundPort).uploadQuality(any(), any());
+    }
+
+    /**
+     * Scenario: AC4b — intentional rename of both technical name and display name creates new check identity without this conflict
+     * Given Blindata already has Quality Suite "sales - orders"
+     * And the suite contains Quality Check code "sales - orders - old_rule" name "Old Display"
+     * And the descriptor quality object has name "new_rule"
+     * And customProperties.displayName is "New Display"
+     * When QUALITY_UPLOAD runs the conflict guard
+     * Then no name/code conflict warning is emitted for that check
+     */
+    @Test
+    void testNoWarnWhenBothNameAndDisplayChange() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("new_rule", "New Display")
+        ));
+        stubExistingSuite();
+        when(blindataOutboundPort.findQualityChecks(any())).thenReturn(Collections.singletonList(
+                existingCheck("sales - orders - old_rule", "Old Display")
+        ));
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        verifyNoConflictWarn();
+    }
+
+    /**
+     * Scenario: AC5 — first upload / suite absent is a no-op for the guard
+     * Given Blindata does not contain Quality Suite "sales - orders"
+     * And the descriptor defines one or more quality checks
+     * When QUALITY_UPLOAD runs the conflict guard
+     * Then findQualitySuiteByCode returns empty
+     * And no name/code conflict warning is emitted
+     * And upload proceeds as today
+     */
+    @Test
+    void testSuiteAbsentIsNoOp() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("new_rule", "Customer Completeness")
+        ));
+        when(blindataOutboundPort.findQualitySuiteByCode(SUITE_CODE)).thenReturn(Optional.empty());
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        verify(blindataOutboundPort, never()).findQualityChecks(any());
+        verifyNoConflictWarn();
+        verify(blindataOutboundPort).uploadQuality(any(), any());
+    }
+
+    /**
+     * Scenario: Fuzzy Blindata search must not false-positive without exact name match
+     * Given Blindata suite-scoped search returns a check whose name only partially matches the incoming name
+     * When the conflict guard post-filters by exact name equality
+     * Then no conflict warning is emitted for that partial match
+     */
+    @Test
+    void testExactNameMatchRequired() throws UseCaseExecutionException {
+        stubDataProductAndUpload();
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("new_rule", "Customer Completeness")
+        ));
+        stubExistingSuite();
+        when(blindataOutboundPort.findQualityChecks(any())).thenReturn(Collections.singletonList(
+                existingCheck("sales - orders - other", "Customer")
+        ));
+
+        new QualityUpload(blindataOutboundPort, odmOutboundPort).execute();
+
+        verifyNoConflictWarn();
+    }
+
+    /**
+     * Scenario: AC6 — observer validator dry-run surfaces conflict and fails policy evaluation
+     * Given QUALITY_UPLOAD runs under ValidatorUseCaseLogger (validator dry-run path)
+     * And Blindata already has Quality Suite "sales - orders" with an existing same-name / different-code check
+     * And the descriptor produces a conflicting incoming check
+     * And dry-run stubs uploadQuality but still performs suite/check read lookups
+     * When the use case executes
+     * Then ValidatorUseCaseLogger collects the conflict warning(s)
+     * And rawError-equivalent warning list contains [#121]
+     */
+    @Test
+    void testValidatorLoggerCollectsConflictOnDryRun() throws UseCaseExecutionException {
+        QualityUploadBlindataOutboundPort livePort = mock(QualityUploadBlindataOutboundPort.class);
+        QualityUploadBlindataOutboundPort dryRunPort = new QualityUploadBlindataOutboundPortDryRunImpl(livePort);
+
+        DataProductVersion dpv = dataProductVersion();
+        when(odmOutboundPort.getDataProductVersion()).thenReturn(dpv);
+        when(odmOutboundPort.extractQualityChecks(any())).thenReturn(Collections.singletonList(
+                qualityCheck("new_rule", "Customer Completeness")
+        ));
+        when(livePort.findIssueCampaign(any())).thenReturn(Optional.empty());
+        when(livePort.findQualitySuiteByCode(SUITE_CODE)).thenReturn(Optional.of(existingSuite()));
+        when(livePort.findQualityChecks(any())).thenReturn(Collections.singletonList(
+                existingCheck("sales - orders - old_rule", "Customer Completeness")
+        ));
+
+        ValidatorUseCaseLogger validatorLogger = new ValidatorUseCaseLogger();
+        UseCaseLoggerContext.setUseCaseLogger(validatorLogger);
+        try {
+            new QualityUpload(dryRunPort, odmOutboundPort).execute();
+        } finally {
+            UseCaseLoggerContext.setUseCaseLogger(mockLogger);
+        }
+
+        assertThat(validatorLogger.getWarnings()).anySatisfy(message ->
+                assertThat(message).contains("[#121]").contains("Customer Completeness")
+        );
+        verify(livePort).findQualitySuiteByCode(SUITE_CODE);
+        verify(livePort).findQualityChecks(any(QualityCheckSearchOptions.class));
+        verify(livePort, never()).uploadQuality(any(), any());
+    }
+
+    private void stubDataProductAndUpload() {
+        when(odmOutboundPort.getDataProductVersion()).thenReturn(dataProductVersion());
+        when(blindataOutboundPort.findIssueCampaign(any())).thenReturn(Optional.empty());
+        when(blindataOutboundPort.createIssueCampaign(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(blindataOutboundPort.uploadQuality(any(), any())).thenReturn(new BDQualityUploadResultsRes());
+    }
+
+    private void stubExistingSuite() {
+        when(blindataOutboundPort.findQualitySuiteByCode(SUITE_CODE)).thenReturn(Optional.of(existingSuite()));
+    }
+
+    private void verifyNoConflictWarn() {
+        verify(mockLogger, never()).warn(argThat(message -> message != null && message.contains("[#121]")));
+    }
+
+    private DataProductVersion dataProductVersion() {
+        DataProductVersion dataProductVersion = new DataProductVersion();
+        Info info = new Info();
+        info.setFullyQualifiedName("urn:dp:sales:orders");
+        info.setDomain("sales");
+        info.setName("orders");
+        dataProductVersion.setInfo(info);
+        InterfaceComponents interfaceComponents = new InterfaceComponents();
+        dataProductVersion.setInterfaceComponents(interfaceComponents);
+        return dataProductVersion;
+    }
+
+    private QualityCheck qualityCheck(String code, String name) {
+        QualityCheck qualityCheck = new QualityCheck();
+        qualityCheck.setCode(code);
+        qualityCheck.setName(name);
+        qualityCheck.setSuccessThreshold(BigDecimal.valueOf(100));
+        qualityCheck.setWarningThreshold(BigDecimal.valueOf(80));
+        return qualityCheck;
+    }
+
+    private BDQualitySuiteRes existingSuite() {
+        BDQualitySuiteRes suite = new BDQualitySuiteRes();
+        suite.setUuid(SUITE_UUID);
+        suite.setCode(SUITE_CODE);
+        suite.setName(SUITE_CODE);
+        return suite;
+    }
+
+    private BDQualityCheckRes existingCheck(String code, String name) {
+        BDQualityCheckRes check = new BDQualityCheckRes();
+        check.setCode(code);
+        check.setName(name);
+        return check;
+    }
+}


### PR DESCRIPTION
- Added a pre-upload guard in the QualityUpload use case to detect and warn about conflicts between incoming quality checks and existing checks in Blindata that share the same display name but have different codes.
- Enhanced the BdQualityClient to support fetching quality suites and checks for conflict detection.
- Updated documentation to reflect the new validation logic and its implications for quality check uploads.